### PR TITLE
Add benchmark artifact to the ci

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -35,6 +35,7 @@ jobs:
               ./install.sh -y
               make -j 4
               make -j 4 doc
+              dune exec benchmark > benchmark.md
             endGroup
           uninstall: |
             startGroup "Clean project"
@@ -46,6 +47,12 @@ jobs:
         with:
           name: docs-artifact
           path: docs
+
+      - name: Upload benchmark
+        uses: actions/upload-artifact@master
+        with:
+          name: benchmark
+          path: benchmark.md
 
       - name: Revert permissions
         # to avoid a warning at cleanup time

--- a/bin/benchmark.ml
+++ b/bin/benchmark.ml
@@ -103,6 +103,11 @@ let test_cases =
     "((q -> (p ∨  r)) ∧ (t -> p)) -> t";
     "((~t -> (q  ∧ p)) ∧ (t -> p)) -> t";
     "(~p ∧ q) -> (p ∨ r -> t) -> o";
+    "((s ∨ r) ∨ (⊥ ∨ r)) ∧ ((⊥ ∨ p) ∨ (t → s))";
+    "((t ∧ r) ∨ (t ∧ s)) ∧ ((r ∧ p) ∧ (p → t))";
+    "((t ∧ t) ∨ (t → s)) ∧ (~s ∧ (⊥ → r))";
+    "(t ∨ r) → (t ∧ s)";
+    
   ]
 
 let _ = bench test_cases


### PR DESCRIPTION
I've added a step to the CI that uploads the benchmark results as artifacts. In the future, it might be beneficial to store the latest benchmark results, perhaps within the repository itself, and implement an automated comparison process.