### PR TITLE
Improve simplifications

### DIFF
--- a/bin/benchmark.ml
+++ b/bin/benchmark.ml
@@ -27,11 +27,12 @@ let time f x =
   { value = fx; time = Sys.time () -. t }
 
 let print_value_results { name; before; after } =
-  Printf.printf "| %s | %d | %d | %.2f | %.4f |\n" name before.value after.value
+  Printf.printf "| %s | %d | %d | %.2f | %.4f | %.4f |\n" name before.value
+    after.value
     (percentage_reduction
        (float_of_int before.value)
        (float_of_int after.value))
-    before.time
+    before.time after.time
 
 let bench_one fs =
   let f = eval fs in
@@ -55,8 +56,9 @@ let bench_one fs =
 let print_bench_value_info benches =
   Printf.printf
     "| Formula | Interpolant weight | Simplified interpolant weight | \
-     Percentage reduction |Interpolant computation time (s)|\n\
-     |--|--|--|--|--|\n";
+     Percentage reduction | Interpolant computation time (s)| Simplification \
+     computation time (s)|\n\
+     |--|--|--|--|--|--|\n";
   List.iter print_value_results benches;
   print_newline ();
 

--- a/theories/iSL/Simp.v
+++ b/theories/iSL/Simp.v
@@ -9,7 +9,6 @@ Definition obviously_smaller (φ : form) ψ :=
   else if decide (φ = ψ) then Lt
   else Eq.
 
-
 Definition choose_or φ ψ :=
 match obviously_smaller φ ψ with
   | Lt => ψ
@@ -26,10 +25,9 @@ match (φ, ψ) with
       | Eq => φ ∨ (ψ1 ∨ ψ2)
       end
   | (φ, ψ1 ∧ ψ2) => 
-      match obviously_smaller φ ψ1 with
-      | Gt => φ
-      | _ => φ ∨ (ψ1 ∧ ψ2)
-      end
+      if decide (obviously_smaller φ ψ1 = Gt )
+      then φ
+      else φ ∨ (ψ1 ∧ ψ2)
   |(φ,ψ) => choose_or φ ψ
 end.
 
@@ -60,10 +58,9 @@ match (φ, ψ) with
       | Eq => φ ∧ (ψ1 ∧ ψ2)
       end
   | (φ, ψ1 ∨ ψ2) => 
-      match obviously_smaller φ ψ1 with
-      | Lt => φ
-      | _ => φ ∧ (ψ1 ∨ ψ2)
-       end 
+      if decide (obviously_smaller φ ψ1 = Lt )
+      then φ
+      else φ ∧ (ψ1 ∨ ψ2)
   |(φ,ψ) => choose_and φ ψ
 end.
 
@@ -110,9 +107,8 @@ Lemma preorder_singleton  φ ψ:
   {[φ]} ⊢ ψ -> (φ ≼ ψ).
 Proof.
 intro H.
-assert (H3: (φ ≼ ψ) = ({[φ]} ⊢ ψ)) by (apply proper_Provable; ms).
-rewrite H3.
-apply H.
+assert (H': ∅ • φ ⊢ ψ ) by peapply H.
+apply H'.
 Qed.
 
 Corollary cut2 φ ψ θ:
@@ -164,8 +160,7 @@ case decide in H.
 Qed.
 
 Lemma or_congruence φ ψ φ' ψ':
-  (φ ≼ φ') -> (ψ ≼ ψ') ->
-  (φ ∨ ψ) ≼ φ' ∨ ψ'.
+  (φ ≼ φ') -> (ψ ≼ ψ') -> (φ ∨ ψ) ≼ φ' ∨ ψ'.
 Proof.
 intros Hφ Hψ.
 apply OrL.
@@ -174,15 +169,13 @@ apply OrL.
 Qed.
 
 
-Lemma or_comm φ ψ:
-  φ ∨ ψ ≼  ψ ∨ φ.
+Lemma or_comm φ ψ: φ ∨ ψ ≼  ψ ∨ φ.
 Proof.
 apply OrL; [apply OrR2 | apply OrR1]; apply generalised_axiom.
 Qed.
 
 
-Lemma or_comm_ctx_L φ ψ ϴ:
-  (φ ∨ ψ ≼ ϴ) -> ψ ∨ φ ≼ ϴ.
+Lemma or_comm_ctx_L φ ψ ϴ: (φ ∨ ψ ≼ ϴ) -> ψ ∨ φ ≼ ϴ.
 Proof.
 intro H.
 eapply cut2.
@@ -190,8 +183,7 @@ apply or_comm.
 assumption.
 Qed.
 
-Lemma or_comm_ctx_R φ ψ ϴ:
-  (ϴ ≼ φ ∨ ψ ) -> ϴ ≼ ψ ∨ φ.
+Lemma or_comm_ctx_R φ ψ ϴ: (ϴ ≼ φ ∨ ψ ) -> ϴ ≼ ψ ∨ φ.
 Proof.
 intro H.
 eapply cut2.
@@ -199,8 +191,7 @@ apply H.
 apply or_comm.
 Qed.
 
-Lemma or_assoc_R φ ψ ϴ :
-  ((φ ∨ ψ) ∨ ϴ  ≼ φ ∨ (ψ ∨ ϴ)).
+Lemma or_assoc_R φ ψ ϴ : ((φ ∨ ψ) ∨ ϴ  ≼ φ ∨ (ψ ∨ ϴ)).
 Proof.
   apply OrL.
   - apply OrL.
@@ -209,8 +200,7 @@ Proof.
   - apply OrR2; apply OrR2; apply generalised_axiom.
 Qed.
 
-Lemma or_assoc_L φ ψ ϴ :
-  (φ ∨ (ψ ∨ ϴ)  ≼ (φ ∨ ψ) ∨ ϴ).
+Lemma or_assoc_L φ ψ ϴ : (φ ∨ (ψ ∨ ϴ)  ≼ (φ ∨ ψ) ∨ ϴ).
 Proof.
   apply OrL.
   - apply OrR1; apply OrR1; apply generalised_axiom.
@@ -256,22 +246,31 @@ Lemma choose_or_equiv_L φ ψ φ' ψ':
 Proof.
 intros Hφ Hψ.
 unfold choose_or.
-case (decide (obviously_smaller φ' ψ' = Lt)); [intro HLt | intro Hneq1].
--rewrite HLt. apply OrL.
+case_eq (obviously_smaller φ' ψ'); intro Heq.
+- apply or_congruence; assumption.
+- apply OrL.
   + eapply cut2. 
     * apply Hφ.
     * apply obviously_smaller_compatible_LT; assumption.
-  + assumption. - case (decide (obviously_smaller φ' ψ' = Gt)); [intro HGt| intro Hneq2].
-  + rewrite HGt. apply OrL.
-    * assumption.
+  + assumption. 
+- apply OrL.
+  + assumption.
+  + eapply cut2.
     * eapply cut2.
-      -- eapply cut2.
-         ++ apply Hψ.
-         ++ apply obviously_smaller_compatible_GT. apply HGt.
-      -- apply generalised_axiom.
-  + case (decide (obviously_smaller φ' ψ' = Eq)); [intro HEq| intro Hneq3].
-    * rewrite HEq. apply or_congruence; [apply Hφ | apply Hψ].
-    * destruct (obviously_smaller φ' ψ'); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
+      -- apply Hψ.
+      -- apply obviously_smaller_compatible_GT. apply Heq.
+    * apply generalised_axiom.
+Qed.
+
+
+Lemma choose_or_equiv_R φ ψ φ' ψ' : 
+  (φ' ≼ φ) -> (ψ' ≼ ψ) ->
+  choose_or φ' ψ' ≼  φ ∨ ψ.
+Proof.
+intros Hφ Hψ.
+unfold choose_or.
+case_eq (obviously_smaller φ' ψ'); intro Heq;
+[apply or_congruence| apply OrR2| apply OrR1]; assumption.
 Qed.
 
 Lemma simp_or_equiv_L φ ψ φ' ψ' : 
@@ -282,44 +281,26 @@ intros Hφ Hψ.
 unfold simp_or.
 destruct ψ'; try (apply choose_or_equiv_L; assumption).
 - case (decide (obviously_smaller φ' ψ'1 = Gt)); [intro HGt | intro Hneq1].
-  + rewrite HGt. apply OrL.
+  + apply OrL.
     * assumption.
     * eapply cut2.
       -- apply Hψ.
       -- apply AndL; apply weakening; now apply obviously_smaller_compatible_GT.
-  + destruct (obviously_smaller φ' ψ'1);
-    [idtac|idtac|contradict Hneq1; auto]; (apply or_congruence; [apply Hφ | apply Hψ]).
-- (case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq1]).
-  + rewrite HLt. apply OrL.
+  + apply or_congruence; assumption.
+- case_eq (obviously_smaller φ' ψ'1); intro Heq.
+  + apply or_congruence; assumption.
+  + apply OrL.
     * eapply cut2. 
       -- apply Hφ.
       -- apply OrR1. apply obviously_smaller_compatible_LT; assumption.
     * assumption.
-  + case (decide (obviously_smaller φ' ψ'1 = Gt)); [intro HGt| intro Hneq2].
-    * rewrite HGt. apply OrL.
-      -- apply OrR1; assumption.
-      -- eapply cut2.
-         ++ apply Hψ. 
-         ++ apply or_congruence; [apply obviously_smaller_compatible_GT; assumption| apply generalised_axiom].
-    * case (decide (obviously_smaller φ' ψ'1 = Eq)); [intro HEq| intro Hneq3].
-      -- rewrite HEq. apply or_congruence; [apply Hφ | apply Hψ].
-      -- destruct (obviously_smaller φ' ψ'1); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
+  + apply OrL.
+    * apply OrR1; assumption.
+    * eapply cut2.
+      -- apply Hψ. 
+      -- apply or_congruence; [apply obviously_smaller_compatible_GT; assumption| apply generalised_axiom].
 Qed.
 
-Lemma choose_or_equiv_R φ ψ φ' ψ' : 
-  (φ' ≼ φ) -> (ψ' ≼ ψ) ->
-  choose_or φ' ψ' ≼  φ ∨ ψ.
-Proof.
-intros Hφ Hψ.
-unfold choose_or.
-case (decide (obviously_smaller φ' ψ' = Lt)); [intro HLt | intro Hneq1].
-- rewrite HLt. apply OrR2; assumption.
-- case (decide (obviously_smaller φ' ψ' = Gt)); [intro HGt| intro Hneq2].
-  + rewrite HGt. apply OrR1; assumption.
-  + case (decide (obviously_smaller φ' ψ' = Eq)); [intro HEq| intro Hneq3].
-    * rewrite HEq. apply or_congruence; [apply Hφ | apply Hψ].
-    * destruct (obviously_smaller φ' ψ'); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
-Qed.
 
 
 Lemma simp_or_equiv_R φ ψ φ' ψ' : 
@@ -328,22 +309,21 @@ Lemma simp_or_equiv_R φ ψ φ' ψ' :
 Proof.
 intros Hφ Hψ.
 unfold simp_or.
-destruct ψ'; try (apply choose_or_equiv_R; assumption).
-- case (decide (obviously_smaller φ' ψ'1 = Gt)); [intro HGt | intro Hneq1].
- + rewrite HGt. now apply OrR1.
- + destruct (obviously_smaller φ' ψ'1);
-    [idtac|idtac|contradict Hneq1; auto]; (apply or_congruence; [apply Hφ | apply Hψ]).
-- case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq1].
- + rewrite HLt. apply OrR2; assumption.
- + case (decide (obviously_smaller φ' ψ'1 = Gt)); [intro HGt| intro Hneq2].
-   * rewrite HGt. apply OrL.
-     -- apply OrR1; assumption.
-     -- apply OrL_rev in Hψ.
-        apply OrR2.
-        apply Hψ.
-   * case (decide (obviously_smaller φ' ψ'1 = Eq)); [intro HEq| intro Hneq3].
-     -- rewrite HEq. apply or_congruence; [apply Hφ | apply Hψ].
-     -- destruct (obviously_smaller φ' ψ'1); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
+destruct ψ'.
+- apply choose_or_equiv_R; assumption.
+- apply choose_or_equiv_R; assumption.
+- case (decide (obviously_smaller φ' ψ'1 = Gt)); intro.
+  + now apply OrR1.
+  + apply or_congruence; assumption.
+- case_eq (obviously_smaller φ' ψ'1); intro Heq.
+ + apply or_congruence; assumption.
+ + apply OrR2; assumption.
+ + apply OrL.
+   * apply OrR1; assumption.
+   * apply OrL_rev in Hψ.
+     apply OrR2, Hψ.
+- apply choose_or_equiv_R; assumption.
+- apply choose_or_equiv_R; assumption.
 Qed.
 
 Lemma simp_or_comm φ ψ :
@@ -551,13 +531,10 @@ Lemma choose_and_equiv_L φ ψ φ' ψ':
 Proof.
 intros Hφ Hψ.
 unfold choose_and.
-case (decide (obviously_smaller φ' ψ' = Lt)); [intro HLt | intro Hneq1].
-- rewrite HLt. apply AndL. apply weakening. apply Hφ.
-- case (decide (obviously_smaller φ' ψ' = Gt)); [intro HGt| intro Hneq2].
-  + rewrite HGt. apply AndL. exch 0. apply weakening. apply Hψ.
-  + case (decide (obviously_smaller φ' ψ' = Eq)); [intro HEq| intro Hneq3].
-    * rewrite HEq. apply and_congruence; [apply Hφ | apply Hψ].
-    * destruct (obviously_smaller φ' ψ'); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
+case_eq (obviously_smaller φ' ψ'); intro Heq.
+- apply and_congruence; assumption.
+- apply AndL, weakening, Hφ.
+- apply AndL. exch 0. apply weakening, Hψ.
 Qed.
 
 
@@ -567,21 +544,18 @@ Lemma choose_and_equiv_R φ ψ φ' ψ':
 Proof.
 intros Hφ Hψ.
 unfold choose_and.
-case (decide (obviously_smaller φ' ψ' = Lt)); [intro HLt | intro Hneq1].
-- rewrite HLt. apply AndR.
+case_eq (obviously_smaller φ' ψ'); intro Heq.
+- apply and_congruence; assumption.
+- apply AndR.
   + assumption.
   + eapply cut2.
-    * apply obviously_smaller_compatible_LT. apply HLt.
+    * apply obviously_smaller_compatible_LT, Heq.
     * assumption.
-- case (decide (obviously_smaller φ' ψ' = Gt)); [intro HGt| intro Hneq2].
-  + rewrite HGt. apply AndR.
-    * eapply cut2.
-      -- apply obviously_smaller_compatible_GT. apply HGt.
-      -- assumption.
+- apply AndR.
+  + eapply cut2.
+    * apply obviously_smaller_compatible_GT, Heq.
     * assumption.
-  + case (decide (obviously_smaller φ' ψ' = Eq)); [intro HEq| intro Hneq3].
-    * rewrite HEq. apply and_congruence; [apply Hφ | apply Hψ].
-    * destruct (obviously_smaller φ' ψ'); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
+  + assumption.
 Qed.
 
 
@@ -592,19 +566,15 @@ Proof.
 intros Hφ Hψ.
 unfold simp_and.
 destruct ψ'; try (apply choose_and_equiv_L; assumption).
-- case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq1].
-  + rewrite HLt. apply and_congruence.
+- case_eq (obviously_smaller φ' ψ'1); intro Heq.
+  + apply and_congruence; assumption.
+  + apply and_congruence.
     * assumption.
     * apply AndR_rev in Hψ; apply Hψ.
-  + case (decide (obviously_smaller φ' ψ'1 = Gt)); [intro HGt| intro Hneq2].
-    * rewrite HGt. apply AndL. exch 0. apply weakening. assumption.
-    * case (decide (obviously_smaller φ' ψ'1 = Eq)); [intro HEq| intro Hneq3].
-      -- rewrite HEq. apply and_congruence; [apply Hφ | apply Hψ].
-      -- destruct (obviously_smaller φ' ψ'1); [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
-- case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq1].
- + rewrite HLt. apply AndL. now apply weakening.
- + destruct (obviously_smaller φ' ψ'1);
-    [idtac | contradict Hneq1; auto | idtac]; (apply and_congruence; [apply Hφ | apply Hψ]).
+  + apply AndL. exch 0. apply weakening. assumption.
+- case (decide (obviously_smaller φ' ψ'1 = Lt)); intro.
+  + apply AndL. now apply weakening.
+  + apply and_congruence; assumption.
 Qed.
 
 Lemma simp_and_equiv_R φ ψ φ' ψ' : 
@@ -613,32 +583,31 @@ Lemma simp_and_equiv_R φ ψ φ' ψ' :
 Proof.
 intros Hφ Hψ.
 unfold simp_and.
-destruct ψ'; try (apply choose_and_equiv_R; assumption).
-- case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq1].
-  + rewrite HLt. apply AndR.
+destruct  ψ'.
+- apply choose_and_equiv_R; assumption.
+- apply choose_and_equiv_R; assumption.
+- case_eq (obviously_smaller φ' ψ'1); intro Heq.
+  + apply and_congruence; assumption.
+  + apply AndR.
     * apply AndL. apply weakening; assumption.
     * apply (cut2 _ ( ψ'1 ∧ ψ'2) _).
       -- apply and_congruence; 
          [now apply obviously_smaller_compatible_LT | apply generalised_axiom].
       -- assumption.
-  + case (decide (obviously_smaller φ' ψ'1 = Gt)); [intro HGt| intro Hneq2].
-    * rewrite HGt. apply AndR.
-      -- apply AndL. apply weakening. eapply cut2.
-         ++ apply obviously_smaller_compatible_GT; apply HGt.
-         ++ assumption.
+  + apply AndR.
+    * apply AndL. apply weakening. eapply cut2.
+      -- apply obviously_smaller_compatible_GT; apply Heq.
       -- assumption.
-    * case (decide (obviously_smaller φ' ψ'1 = Eq)); [intro HEq| intro Hneq3].
-      -- rewrite HEq. apply and_congruence; [apply Hφ | apply Hψ].
-      -- destruct (obviously_smaller φ' ψ'1);
-         [contradict Hneq3 | contradict Hneq1 |contradict Hneq2]; trivial.
-- case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq1].
- + rewrite HLt. apply AndR.
+    * assumption.
+- case (decide (obviously_smaller φ' ψ'1 = Lt)); [intro HLt | intro Hneq].
+  + apply AndR.
     * assumption.
     * eapply cut2.
       -- apply obviously_smaller_compatible_LT; apply HLt.
       -- apply OrL_rev in Hψ; apply Hψ.
- + destruct (obviously_smaller φ' ψ'1);
-    [idtac | contradict Hneq1; auto | idtac]; (apply and_congruence; [apply Hφ | apply Hψ]).
+  + apply and_congruence; assumption.
+- apply choose_and_equiv_R; assumption.
+- apply choose_and_equiv_R; assumption.
 Qed.
 
 Lemma simp_and_comm φ ψ :
@@ -1002,7 +971,7 @@ Lemma vars_incl_simp_ands φ ψ V :
 Proof.
 generalize ψ.
 induction φ; intro ψ0; destruct ψ0; intros Hφ Hψ;
-try ( apply vars_incl_simp_and_equiv_and; apply and_vars_incl; assumption).
+try (apply vars_incl_simp_and_equiv_and; apply and_vars_incl; assumption).
 simpl.
 apply vars_incl_simp_and_equiv_and.
 apply and_vars_incl.


### PR DESCRIPTION
I've added a few more improvement to the simplifications:

These new rules:
```math
\text {if } \phi \preccurlyeq \psi  \text { then } \phi \implies \psi \equiv \top
```
```math
\text {if } \phi \preccurlyeq \bot  \text { then } \phi \implies \psi \equiv \top
```
```math
\text {if } \top \preccurlyeq \psi  \text { then } \phi \implies \psi \equiv \top
```
```math
\text {if } \top \preccurlyeq \phi  \text { then } \phi \implies \psi \equiv \psi
```
```math
\text {if } \psi \preccurlyeq \bot  \text { then } \phi \implies \psi \equiv \neg\phi
```

And `obviously_smaller` now looks in disjunctions and conjunctions recursively to find if one is smaller than the other.