### PR TITLE
Simplifications simplify proof

### DIFF
--- a/theories/extraction/UIML_extraction.v
+++ b/theories/extraction/UIML_extraction.v
@@ -41,5 +41,5 @@ Definition isl_simplified_A v f := A_simplified v f.
 
 Set Extraction Output Directory "extraction".
 
-Separate Extraction gl_UI k_UI isl_E isl_A isl_simplified_E isl_simplified_A Formulas.weight isl_simp.
+Separate Extraction gl_UI k_UI isl_E isl_A isl_simplified_E isl_simplified_A Formulas.weight Formulas.form_size isl_simp.
 

--- a/theories/iSL/Formulas.v
+++ b/theories/iSL/Formulas.v
@@ -135,3 +135,13 @@ Global Instance irreflexive_form_order : Irreflexive form_order.
 Proof. unfold form_order. intros x y. lia. Qed.
 
 Notation "φ ≺f ψ" := (form_order ψ φ) (at level 149).
+
+
+Fixpoint form_size (φ : form) : nat := match φ with
+| ⊥ => 1
+| Var _ => 1
+| φ ∧ ψ => 1 + form_size φ + form_size ψ
+| φ ∨ ψ => 1 + form_size φ + form_size ψ
+| φ → ψ => 1 + form_size φ + form_size ψ
+| □φ => 1 + form_size φ
+end.


### PR DESCRIPTION
I've added a small theorem that states simplifications do not increase the number of symbols in formulas. This follows a conversation I had with @samvang and @hferee, in which we discussed adopting a more mathematical approach to simplifications by setting a goal and proving that our simplifications are a step toward that goal.

In this case, I used the same measure as the one used in the benchmark (number of symbols) to write the theorem, stating that the number of symbols in a simplified formula is always less than or equal to the original.

I don't see how we could get a better bound that isn't too implementation-dependent. Achieving that would probably require defining some notion of irreducibility, which I think would be hard to formalize in a useful and readable way.

The benchmark was also updated to output a last row in which summarizes the benchmark.