### PR TITLE
Uniformly handle IPC and iSL

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     container:
-      image: coqorg/coq:8.19
+      image: coqorg/coq:8.20.1
       # This is a workaround a "bug" on the checkout action,
       # see https://github.com/actions/checkout/issues/956
       options: --user root

--- a/bin/benchmark.ml
+++ b/bin/benchmark.ml
@@ -26,7 +26,7 @@ let print_value_results { name; before; after } =
        (float_of_int after.value))
     before.time after.time
 
-let weight_int n = weight n |> int_of_nat
+let weight_int n = weight Modal n |> int_of_nat
 
 let bench_one fs =
   let f = eval fs in

--- a/bin/isl_dec.ml
+++ b/bin/isl_dec.ml
@@ -12,6 +12,6 @@ let print_decision = function Coq_inl _ -> "Provable" | _ -> "Not provable"
 
 let () =
   if nb_args = 2 then
-    form |> eval |> coq_Provable_dec [] |> print_decision |> print_string
+    form |> eval |> coq_Provable_dec Modal [] |> print_decision |> print_string
     |> print_newline
   else print_string usage_string

--- a/bin/modal_expressions_parser.ml
+++ b/bin/modal_expressions_parser.ml
@@ -13,30 +13,30 @@ let parens p = char '(' *> p <* char ')'
 let box p = ((char '[' *> char ']') <|> (char '\xE2' *> char '\x96' *> char '\xA1')) *> spaces *> p
   >>| fun x -> Box x
 let diamond p = ((char '<' *> char '>') <|> (char '\xE2' *> char '\x8B' *> char '\x84')) *> spaces *> p
-  >>| fun x -> Implies (Box (Implies(x, Bot)), Bot)
+  >>| fun x -> Implies (Modal, Box (Implies(Modal, x, Bot Modal)), Bot Modal)
 
 let neg p = ((char '~') <|> (char '\xC2' *> char '\xAC')) *> spaces *> p
-  >>| fun x -> Implies(x, Bot)
+  >>| fun x -> Implies(Modal, x, Bot Modal)
 
-let disj = spaces *> ((char '\xE2' *> char '\x88' *> char '\xA8') <|> char '|') *> spaces *>  return (fun x y -> Or(x, y))
-let conj = spaces *> ((char '\xE2' *> char '\x88' *> char '\xA7') <|> char '&') *> spaces *> return (fun x y -> And (x, y))
+let disj = spaces *> ((char '\xE2' *> char '\x88' *> char '\xA8') <|> char '|') *> spaces *>  return (fun x y -> Or(Modal, x, y))
+let conj = spaces *> ((char '\xE2' *> char '\x88' *> char '\xA7') <|> char '&') *> spaces *> return (fun x y -> And (Modal, x, y))
 
 let modal (p : form t) : form t = box p <|> neg p <|> diamond p
 let impl = spaces *> ((char '\xE2' *> char '\x86' *> char '\x92') <|> (char '-' *> char '>')) *> spaces *>
-  return (fun x y -> Implies(x, y))
+  return (fun x y -> Implies(Modal, x, y))
 let iff = spaces *> ((char '\xE2' *> char '\x86' *> char '\x94') <|> (char '<' *> char '-' *> char '>')) *> spaces *>
-  return (fun x y -> And(Implies(x, y), Implies(y, x)))
+  return (fun x y -> And(Modal, Implies(Modal, x, y), Implies(Modal, y, x)))
 
 (* this is ⊥ *)
 let bot = spaces *> ((char '\xE2' *> char '\x8A' *> char '\xA5') <|> char '#'
-                     <|> char 'F') *> spaces *> return (Bot)
-let top = spaces *> ((char '\xE2' *> char '\x8A' *> char '\xA4') <|> char 'T') *> spaces *> return (Implies(Bot,Bot))
+                     <|> char 'F') *> spaces *> return (Bot Modal)
+let top = spaces *> ((char '\xE2' *> char '\x8A' *> char '\xA4') <|> char 'T') *> spaces *> return (Implies(Modal, Bot Modal,Bot Modal))
 
 
 let letter = function | 'a' .. 'z' -> true | _ -> false
 let letter_or_digit = function | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> true | _ -> false
 
-let identifier = lift2 (^) (take_while1 letter) (take_while letter_or_digit) >>| fun x -> Var (coqstring_of_camlstring x)
+let identifier = lift2 (^) (take_while1 letter) (take_while letter_or_digit) >>| fun x -> Var (Modal, coqstring_of_camlstring x)
 
 (* chain of left-associative operations *)
 let chainl1 e op =
@@ -52,14 +52,6 @@ let chainl1 e op =
 let chainmod (e : 'a t) (op : 'a t -> 'a t) : 'a t =
   fix (fun x -> op x <|> e)
 
-  (*
-  let rec go (acc : 'a) = lift (fun f -> f acc) op  *> (e >>= go) <|> return acc in e >>= go
-  *)
-    (*
-  p ‘chainr1‘ op =
-  p ‘bind‘ \x ->
-  [f x y | f <- op, y <- p ‘chainr1‘ op] ++ [x]
-*)
 let expr : form t =
   fix (fun expr ->
     let factor = parens expr <|> identifier <|> bot <|> top in

--- a/bin/printer.ml
+++ b/bin/printer.ml
@@ -10,27 +10,27 @@ let rec int_of_nat = function
 let string_of_formula ?(classical = false) =
   let rec string_of_formula =
   function
-| Var v -> camlstring_of_coqstring v
-| Bot -> "⊥"
-| Implies(Bot, Bot) -> "⊤"
+| Var (_, v) -> camlstring_of_coqstring v
+| Bot _ -> "⊥"
+| Implies(_, Bot _, Bot _) -> "⊤"
 (* diamond *)
-| Implies(Box(Implies(f, Bot)),Bot) when classical -> "⋄ " ^ bracket f
+| Implies(_, Box(Implies(_, f, Bot _)),Bot _) when classical -> "⋄ " ^ bracket f
 (* double negation *)
-| Implies(Implies(f, Bot), Bot) when classical -> string_of_formula f
+| Implies(_, Implies(_, f, Bot _), Bot _) when classical -> string_of_formula f
 | Box f -> "□ " ^ bracket f
-| And (f, g) -> and_bracket f ^ " ∧ " ^ and_bracket g
-| Or (f, g) -> or_bracket f ^ " ∨ " ^ or_bracket g
-| Implies (f, Bot) -> "¬ " ^ bracket f (* pretty print ¬ *)
-| Implies (f, g) -> bracket f ^ " → " ^ bracket g
+| And (_, f, g) -> and_bracket f ^ " ∧ " ^ and_bracket g
+| Or (_, f, g) -> or_bracket f ^ " ∨ " ^ or_bracket g
+| Implies (_, f, Bot _) -> "¬ " ^ bracket f (* pretty print ¬ *)
+| Implies (_, f, g) -> bracket f ^ " → " ^ bracket g
 and bracket e = match e with
-| Implies(Implies(f, Bot), Bot) when classical -> bracket f
-| Implies(Box(Implies(f, Bot)),Bot) when classical -> "⋄ " ^ bracket f
-| Var _ | Bot | Implies(_, Bot) | Box _ -> string_of_formula e
+| Implies(_, Implies(_, f, Bot _), Bot _) when classical -> bracket f
+| Implies(_, Box(Implies(_, f, Bot _)),Bot _) when classical -> "⋄ " ^ bracket f
+| Var _ | Bot _| Implies(_, _, Bot _) | Box _ -> string_of_formula e
 | e -> "(" ^ string_of_formula e ^ ")"
 and or_bracket e = match e with
-| Or (f, g) -> or_bracket f ^ " ∨ " ^ or_bracket g
+| Or (_, f, g) -> or_bracket f ^ " ∨ " ^ or_bracket g
 | _ -> bracket e
 and and_bracket e = match e with
-| And (f, g) -> and_bracket f ^ " ∧ " ^ and_bracket g
+| And (_, f, g) -> and_bracket f ^ " ∧ " ^ and_bracket g
 | _ -> bracket e
   in string_of_formula

--- a/bin/stringconversion.ml
+++ b/bin/stringconversion.ml
@@ -26,4 +26,3 @@ let coqstring_of_camlstring s =
   let rec cstring accu pos =
     if pos < 0 then accu else cstring (s.[pos] :: accu) (pos - 1)
   in cstring [] (String.length s - 1)
-  

--- a/bin/uiml_cmdline.ml
+++ b/bin/uiml_cmdline.ml
@@ -19,11 +19,11 @@ let rec l_e_formulas = lazy
     begin
       let r_formulas = pay l_e_formulas in
       union
-	[ single Bot ;
-    map e_vars (fun x -> Var x) ;
-	  map (pair r_formulas r_formulas) (fun (t1, t2) -> And (t1, t2)) ;
-    map (pair r_formulas r_formulas) (fun (t1, t2) -> Or (t1, t2)) ;
-    map (pair r_formulas r_formulas) (fun (t1, t2) -> Implies (t1, t2)) ;
+	[ single (Bot Modal) ;
+    map e_vars (fun x -> Var (Modal, x)) ;
+	  map (pair r_formulas r_formulas) (fun (t1, t2) -> And (Modal, t1, t2)) ;
+    map (pair r_formulas r_formulas) (fun (t1, t2) -> Or (Modal, t1, t2)) ;
+    map (pair r_formulas r_formulas) (fun (t1, t2) -> Implies (Modal, t1, t2)) ;
     map r_formulas (fun x -> Box x);
 	]
     end
@@ -52,18 +52,18 @@ let v : variable = coqstring_of_camlstring "p"
 
 let show_test (f: form) : string =
     ("φ        : " ^ string_of_formula f ^ "\n" ^
-                 "Weight: " ^ string_of_int (int_of_nat (weight f)) ^ "\n") ^
+                 "Weight: " ^ string_of_int (int_of_nat (weight Modal f)) ^ "\n") ^
     let t_start = Sys.time() in
     let e_result = isl_simplified_E v f in
     let run_time = Sys.time() -. t_start in
     ("Time: " ^ string_of_float run_time ^ "s\n") ^
     ("Eₚ(φ): " ^
                   string_of_formula e_result ^ "\n" ^
-                 "Weight: " ^ string_of_int (int_of_nat (weight e_result)) ^ "\n") ^
+                 "Weight: " ^ string_of_int (int_of_nat (weight Modal e_result)) ^ "\n") ^
     let a_result = isl_simplified_A v f in
     ("Aₚ(φ): " ^
                  string_of_formula a_result ^ "\n" ^
-                "Weight: " ^ string_of_int (int_of_nat (weight a_result)) ^ "\n-------------------\n")
+                "Weight: " ^ string_of_int (int_of_nat (weight Modal a_result)) ^ "\n-------------------\n")
 
 let () =
   if nb_args = 2 then print_string (show_test (eval form))

--- a/bin/uiml_demo.ml
+++ b/bin/uiml_demo.ml
@@ -10,10 +10,11 @@ let catch_e f = try f() with
 | Failure s -> "Error: " ^ s
 | e -> "Error: " ^ Printexc.to_string e
 
+
 let fail_on_modality (f : form) : form =
   let rec aux = function
   | Box _ -> failwith "The provided formula contains modalities"
-  | Or(x, y) | Implies(x, y) | And(x, y) -> aux x ; aux y
+  | Or(_, x, y) | Implies(_, x, y) | And(_,x, y) -> aux x ; aux y
   | _ -> ()
   in (aux f; f)
 

--- a/bin/weight.ml
+++ b/bin/weight.ml
@@ -12,4 +12,4 @@ let nb_args = Array.length Sys.argv
 
 let form = if nb_args = 2 then (Sys.argv.(1)) else "T"
 
-let () = print_endline (string_of_int (int_of_nat (weight (eval form))))
+let () = print_endline (string_of_int (int_of_nat (weight Modal (eval form))))

--- a/install.sh
+++ b/install.sh
@@ -2,4 +2,4 @@
 
 opam repo add coq-released https://coq.inria.fr/opam/released "$@"
 opam pin coq 8.20.1 "$@"
-opam install coq coq-stdpp angstrom js_of_ocaml js_of_ocaml-ppx exenum "$@"
+opam install coq coq-stdpp coq-equations angstrom js_of_ocaml js_of_ocaml-ppx exenum "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 opam repo add coq-released https://coq.inria.fr/opam/released "$@"
-opam pin coq 8.19.2 "$@"
+opam pin coq 8.20.1 "$@"
 opam install coq coq-stdpp angstrom js_of_ocaml js_of_ocaml-ppx exenum "$@"

--- a/theories/GL/GLS/GLS_termination_measure.v
+++ b/theories/GL/GLS/GLS_termination_measure.v
@@ -483,7 +483,7 @@ intros prem concl RA noIdB. inversion RA. subst. split.
 - apply NoDup_incl_length.
   * apply NoDup_subform_boxesS.
   * intro. intros. unfold subform_boxesS in H. unfold subform_boxesS. simpl. simpl in H.
-    repeat rewrite app_length.  repeat rewrite app_length in H. repeat rewrite remove_list_of_nil.
+    repeat rewrite length_app.  repeat rewrite length_app in H. repeat rewrite remove_list_of_nil.
     repeat rewrite remove_list_of_nil in H. rewrite app_nil_r in H. apply in_app_or in H.
     destruct H. rewrite subform_boxesLF_dist_app in H. apply in_app_or in H. destruct H.
     apply in_or_app. left. apply univ_gen_ext_incl_subform_boxes in X. apply X. pose (XBoxed_list_same_subform_boxes BΓ).
@@ -494,7 +494,7 @@ intros prem concl RA noIdB. inversion RA. subst. split.
     apply remove_list_is_in. apply In_remove_list_In_list in H. rewrite subform_boxesLF_dist_app.
     apply remove_list_is_in. simpl. right. apply in_or_app. auto.
 - intro. intros. unfold subform_boxesS in H. unfold subform_boxesS. simpl. simpl in H.
-  repeat rewrite app_length.  repeat rewrite app_length in H. repeat rewrite remove_list_of_nil.
+  repeat rewrite length_app.  repeat rewrite length_app in H. repeat rewrite remove_list_of_nil.
   repeat rewrite remove_list_of_nil in H. rewrite app_nil_r in H. apply in_app_or in H.
   destruct H. rewrite subform_boxesLF_dist_app in H. apply in_app_or in H. destruct H.
   apply in_or_app. left. apply univ_gen_ext_incl_subform_boxes in X. apply X. pose (XBoxed_list_same_subform_boxes BΓ).

--- a/theories/Syntax/remove_list_lems.v
+++ b/theories/Syntax/remove_list_lems.v
@@ -320,7 +320,7 @@ induction l2.
   * inversion H0.
     + exfalso. apply n. symmetry. assumption.
     + assert (a :: l2 = [a] ++ l2). auto. rewrite H2. rewrite remove_list_dist_app.
-      rewrite app_length. pose (remove_list_singl_id_or_nil l1 a). destruct o.
+      rewrite length_app. pose (remove_list_singl_id_or_nil l1 a). destruct o.
       rewrite H3. simpl. apply Nat.lt_lt_succ_r. apply IHl2 with (A:=A) ; assumption.
       rewrite H3. simpl. rewrite <- Nat.succ_lt_mono. apply IHl2 with (A:=A) ; assumption.
 Qed.
@@ -405,7 +405,7 @@ Lemma keep_list_delete_head_not_origin : forall l1 l2 l3 A, ((In A l1) -> False)
                 length (remove_list l1 (l2 ++ A :: l3)) = S (length (remove_list l1 (l2 ++ l3))).
 Proof.
 induction l1.
-- intros. simpl. rewrite app_length. simpl. rewrite app_length. auto.
+- intros. simpl. rewrite length_app. simpl. rewrite length_app. auto.
 - intros. simpl. repeat rewrite remove_list_dist_app. assert (In A l1 -> False).
   intro. apply H. apply in_cons. assumption. assert (A :: l3 = [A] ++ l3).
   auto. rewrite H1. rewrite remove_list_dist_app. pose (remove_list_singl_id_or_nil l1 A).

--- a/theories/extraction/UIML_extraction.v
+++ b/theories/extraction/UIML_extraction.v
@@ -12,7 +12,7 @@ Require ISL.Simp_env.
 Module Import S := Simp_env.S.
 Module Import SPQr := PropQuant S.
 
-Fixpoint MPropF_of_form (f : Formulas.form) : MPropF  :=
+Program Fixpoint MPropF_of_form (f : Formulas.form) : MPropF  :=
 match f with
 | Formulas.Var n => Var n
 | Formulas.Bot => Bot
@@ -34,15 +34,16 @@ end.
 Definition gl_UI p s := form_of_MPropF (proj1_sig (GL.Interpolation.UIGL_braga.GUI_tot p ([],[MPropF_of_form s]))).
 Definition k_UI p s := form_of_MPropF(proj1_sig (K.Interpolation.UIK_braga.GUI_tot p ([],[MPropF_of_form s]))).
 
-Definition isl_E v f := Ef v f.
-Definition isl_A v f := Af v f.
+Definition isl_E v f := @Ef v Formulas.Modal f.
+Definition isl_A v f := @Af v Formulas.Modal f.
 
 (* simp_form seems to improve over simp in most cases.
   Notable exception: (a ∨b) → c *)
-Definition isl_simp f := simp_form f.
+Definition isl_simp f := @simp_form Formulas.Modal f.
 
-Definition isl_simplified_E p ψ := Ef p ψ.
-Definition isl_simplified_A p ψ := Af p ψ.
+(* For backward compatibility only *)
+Definition isl_simplified_E := isl_E.
+Definition isl_simplified_A := isl_A.
 
 Set Extraction Output Directory "extraction".
 

--- a/theories/general/genT.v
+++ b/theories/general/genT.v
@@ -13,7 +13,7 @@ Require Import gen.
 Polymorphic Definition rlsT W := list W -> W -> Type.
 
 (* how to express the empty set *)
-Inductive emptyT {X : Type} : X -> Type := .
+Inductive emptyT {X : Type} : X -> Prop := .
 
 Lemma emptyT_any': forall (sty : Type) Q (prem : sty), emptyT prem -> Q prem.
 Proof. intros. induction H. Qed.
@@ -24,7 +24,7 @@ Proof. intros. induction H. Qed.
 (* compare 
   https://coq.inria.fr/stdlib/Coq.Relations.Relation_Definitions.html *)
 Polymorphic Definition relationT (A : Type) := A -> A -> Type.
-Inductive empty_relT {A B : Type} : A -> B -> Type := .
+Inductive empty_relT {A B : Type} : A -> B -> Prop := .
 
 Lemma rsub_emptyT {A B} r : @rsub A B empty_relT r.
 Proof. intros u v e. destruct e. Qed.
@@ -477,7 +477,7 @@ Lemma prod_nat_split : forall (P : (nat * nat) -> Type),
 Proof. firstorder. Qed.
 
 
-Inductive empty : Type := .
+Inductive empty : Prop := .
 
 Lemma empty_explosion : forall (A : Type), empty -> A.
 Proof. intros A H. inversion H. Qed.

--- a/theories/iSL/Cut.v
+++ b/theories/iSL/Cut.v
@@ -269,7 +269,7 @@ destruct HPφ; simpl in Hw.
         ++ apply imp_cut with (φ1 → φ2). backward. rw (symmetry Heq) 0.
                 apply BoxR, HPφ.
         ++ exch 0. rw (symmetry (difference_singleton _ _ Hin0)) 1. exact HPψ2.
-  + (* (VIII-b) *) 
+  + (* (VIII-b) *)
       forward. apply ImpBox.
      * (* π0 *)
         apply IHW.

--- a/theories/iSL/Cut.v
+++ b/theories/iSL/Cut.v
@@ -1,12 +1,13 @@
 (** * Cut Admissibility *)
 Require Import ISL.Formulas ISL.Sequents ISL.Order.
 Require Import ISL.SequentProps .
+Require Import Coq.Program.Equality.
 
-Local Hint Rewrite elements_env_add : order.
+Local Hint Rewrite @elements_env_add : order.
 
 
 (* From "A New Calculus for Intuitionistic Strong Löb Logic" *)
-Theorem additive_cut Γ φ ψ :
+Theorem additive_cut {K : Kind} Γ φ ψ :
   Γ ⊢ φ  -> Γ • φ ⊢ ψ ->
   Γ ⊢ ψ.
 Proof.
@@ -25,7 +26,7 @@ destruct HPφ; simpl in Hw.
 - now apply contraction.
 - apply ExFalso.
 - apply AndL_rev in HPψ. do 2 apply IHw in HPψ; trivial; try lia; apply weakening; assumption.
-- apply AndL. apply IHW; auto with proof. order_tac. 
+- apply AndL. apply IHW; auto with proof. order_tac.
 - apply OrL_rev in HPψ; apply (IHw φ); [lia| |]; tauto.
 - apply OrL_rev in HPψ; apply (IHw ψ0); [lia| |]; tauto.
 - apply OrL; apply IHW; auto with proof.
@@ -82,7 +83,7 @@ destruct HPφ; simpl in Hw.
       -- apply weakening, ImpR,  HPφ.
       -- exch 0.  rewrite <- HH. exact HPψ.
   + case (decide ((Var p → φ0) = (φ → ψ0))).
-      * intro Heq'; inversion Heq'; subst. clear Heq'.
+      * intro Heq'; dependent destruction Heq'.
          replace ((Γ0 • Var p • (p → ψ0)) ∖ {[p → ψ0]}) with (Γ0 • Var p) by ms.
          apply (IHw ψ0).
         -- lia.
@@ -94,7 +95,7 @@ destruct HPφ; simpl in Hw.
             rw (symmetry Heq) 0. apply ImpR, HPφ.
         -- exch 0; exch 1. rw (symmetry (difference_singleton _ _ Hin1)) 2. exact HPψ.
   + case (decide (((φ1 ∧ φ2) → φ3)= (φ → ψ0))).
-      * intro Heq'; inversion Heq'; subst. clear Heq'. rw (symmetry Heq) 0.
+      * intro Heq'; dependent destruction Heq'. rw (symmetry Heq) 0.
          apply (IHw (φ1 → φ2 → ψ0)).
         -- simpl in *. lia.
         -- apply ImpR, ImpR, AndL_rev, HPφ.
@@ -104,7 +105,7 @@ destruct HPφ; simpl in Hw.
         -- apply ImpLAnd_rev. backward. rw (symmetry Heq) 0. apply ImpR, HPφ.
         -- exch 0. rw (symmetry (difference_singleton _ _ Hin0)) 1. exact HPψ.
   + case (decide (((φ1 ∨ φ2) → φ3)= (φ → ψ0))).
-      * intro Heq'; inversion Heq'; subst. clear Heq'. rw (symmetry Heq) 0. apply OrL_rev in HPφ.
+      * intro Heq'; dependent destruction Heq'. rw (symmetry Heq) 0. apply OrL_rev in HPφ.
          apply (IHw (φ1 → ψ0)).
         -- simpl in *. lia.
         -- apply (IHw (φ2 → ψ0)).
@@ -120,7 +121,7 @@ destruct HPφ; simpl in Hw.
         -- apply ImpLOr_rev. backward. rw (symmetry Heq) 0. apply ImpR, HPφ.
         -- exch 0. exch 1. rw (symmetry (difference_singleton _ _ Hin0)) 2. exact HPψ.
   + case (decide (((φ1 → φ2) → φ3) = (φ → ψ0))).
-     * intro Heq'. inversion Heq'; subst. clear Heq'. rw (symmetry Heq) 0. apply (IHw ψ0).
+     * intro Heq'. dependent destruction Heq'. rw (symmetry Heq) 0. apply (IHw ψ0).
       -- lia.
       -- apply (IHw(φ1 → φ2)).
         ++ lia.
@@ -144,7 +145,7 @@ destruct HPφ; simpl in Hw.
                 apply ImpR, HPφ.
         ++ exch 0. rw (symmetry (difference_singleton _ _ Hin0)) 1. exact HPψ2.
   + case (decide ((□ φ1 → φ2) = (φ → ψ0))).
-     * intro Heq'. inversion Heq'; subst. clear Heq'. rw (symmetry Heq) 0.
+     * intro Heq'. dependent destruction Heq'. rw (symmetry Heq) 0.
         assert(Γ = Γ0) by ms. subst Γ0. clear Hin.
         apply (IHw (□ φ1)).
       -- lia.
@@ -198,18 +199,17 @@ destruct HPφ; simpl in Hw.
 - remember (Γ • □ φ) as Γ' eqn:HH.
   assert (Heq: Γ ≡ Γ' ∖ {[ □ φ ]}) by ms.
   assert(Hin : (□ φ) ∈ Γ')by ms.
-  rw Heq 0. destruct HPψ.
+  rw Heq 0. dependent destruction HPψ.
   + forward. auto with proof.
   + forward. auto with proof.
   + apply AndR.
      * apply IHW.
-     -- subst. rewrite env_add_remove. otac H.
+     -- rewrite env_add_remove. otac H.
      -- rw (symmetry Heq) 0. now apply BoxR.
      -- peapply HPψ1.
-     * apply IHW.
+     * peapply (IHW Γ).
        -- otac Heq.
-       -- apply BoxR. box_tac. peapply HPφ. rewrite Heq.
-           rewrite open_boxes_remove; trivial.
+       -- apply BoxR. box_tac. peapply HPφ.
        -- peapply HPψ2.
   + forward. apply AndL. apply IHW.
      * otac Heq.
@@ -224,11 +224,13 @@ destruct HPφ; simpl in Hw.
     * rw (symmetry Heq) 0. apply BoxR, HPφ.
     * peapply HPψ.
   + forward. apply BoxR in HPφ.
-       assert(Hin' : (φ0 ∨ ψ) ∈ ((Γ0 • φ0 ∨ ψ) ∖ {[□ φ]}))
+       assert(Hin' : (φ0 ∨ ψ0) ∈ ((Γ0 • φ0 ∨ ψ0) ∖ {[□ φ]}))
             by (apply in_difference; [discriminate|ms]).
-       assert(HPφ' : (((Γ0 • φ0 ∨ ψ) ∖ {[□ φ]}) ∖ {[φ0 ∨ ψ]} • φ0 ∨ ψ) ⊢ □ φ)
-            by (rw (symmetry (difference_singleton _ (φ0 ∨ψ) Hin')) 0; peapply HPφ).
-       assert (HP := (OrL_rev  _ φ0 ψ (□φ) HPφ')).
+       assert(HPφ' : (((Γ0 • φ0 ∨ ψ0) ∖ {[□ φ]}) ∖ {[φ0 ∨ ψ0]} • φ0 ∨ ψ0) ⊢ □ φ).
+       { rw (symmetry (difference_singleton _ (φ0 ∨ ψ0) Hin')) 0.
+         rw (symmetry Heq) 0.
+         exact HPφ. }
+       assert (HP := (OrL_rev  _ φ0 ψ0 (□φ) HPφ')).
        apply OrL.
       * apply IHW.
         -- otac Heq.
@@ -241,7 +243,7 @@ destruct HPφ; simpl in Hw.
   + rw (symmetry Heq) 0. apply ImpR, IHW.
       -- otac Heq.
       -- apply weakening, BoxR,  HPφ.
-      -- exch 0.  rewrite <- HH. exact HPψ.
+      -- exch 0. exact HPψ.
   + do 2 forward. exch 0. apply ImpLVar, IHW.
       * otac Heq.
       * apply imp_cut with (φ := Var p). exch 0. do 2 backward.
@@ -305,7 +307,7 @@ destruct HPφ; simpl in Hw.
 Qed.
 
 (* Multiplicative cut rule *)
-Theorem cut Γ Γ' φ ψ :
+Theorem cut {K : Kind} Γ Γ' φ ψ :
   Γ ⊢ φ  -> Γ' • φ ⊢ ψ ->
   Γ ⊎ Γ' ⊢ ψ.
 Proof.

--- a/theories/iSL/DecisionProcedure.v
+++ b/theories/iSL/DecisionProcedure.v
@@ -1,5 +1,6 @@
 (** * Decision Procedure *)
 Require Import ISL.Sequents ISL.SequentProps ISL.Order.
+Require Import Coq.Program.Equality.
 
 (**
   This file implements a decision procedure for iSL. There are two versions, with the same proof.
@@ -7,7 +8,7 @@ Require Import ISL.Sequents ISL.SequentProps ISL.Order.
   of the sequent.
 *)
 
-Global Instance proper_rm : Proper ((=) ==> (≡ₚ) ==> (≡ₚ)) rm.
+Global Instance proper_rm {K : Kind}: Proper ((=) ==> (≡ₚ) ==> (≡ₚ)) rm.
 Proof.
 intros x y Heq. subst y.
 induction 1; simpl; trivial.
@@ -28,11 +29,43 @@ induction l as [|x l].
     * right. simpl. intros z [Hz|Hz]; subst; try rewrite Heq; auto with *.
 Defined.
 
+(* We declare the decidability lemmas for applicability of modal rules
+  using Program to handle dependent types. *)
+
+Local Definition M_inj {K : Kind} (Heq : K = Modal) (Γ : list form) :=
+  eq_rect K (fun K => list form) Γ Modal Heq.
+
+Local Program Definition HBoxR_tree_spec {K : Kind} (φ: form) (Γ : list form) := 
+  {Heq : K = Modal &
+   {φ' &
+   {Hp : (⊗ (list_to_set_disj (M_inj Heq Γ)) • □ φ' ⊢ φ') & φ = (□ φ')}}}
+ + {match K as K' return (K = K' → Prop) with
+    | Modal => fun Heq => ∀ φ', ∀ (H : ⊗ (list_to_set_disj (M_inj Heq Γ)) • □ φ' ⊢ φ'), φ = (□ φ') -> False
+    | _=> fun _ => True end eq_refl}.
+Next Obligation. intros K φ Γ Heq _ _. exact (symmetry Heq). Defined.
+Next Obligation. intros K φ Γ Heq _ _. exact (symmetry Heq). Defined.
+
+Local Program Definition HImpLBox_tree_spec {K : Kind} (φ: form) (Γ : list form) :=
+  ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ ->
+    {Heq : K = Modal & {φ1 & {φ2 
+      & {H2312 : ((⊗(list_to_set_disj ((rm (Implies (□ φ1) φ2) (M_inj Heq Γ)))) • □ φ1 • φ2) ⊢φ1)
+        & {H3: ((list_to_set_disj (rm (Implies (□ φ1) φ2) (M_inj Heq Γ)) : @env Modal) • φ2 ⊢ φ)
+        & (Implies (□ φ1) φ2) ∈ M_inj Heq Γ2}}}}}
+  + {match K as K' return (K = K' → Prop) with
+     | Modal => fun Heq => ∀ φ1 φ2 (_ : ((⊗ (list_to_set_disj ((rm (Implies (□ φ1) φ2) (M_inj Heq Γ)))) • □ φ1 • φ2) ⊢φ1))
+             (_: (list_to_set_disj (rm (Implies (□ φ1) φ2) (M_inj Heq Γ)) : @env Modal) • φ2 ⊢ φ),
+             Implies (□ φ1) φ2 ∈ M_inj Heq Γ2 → False
+     | _ => fun _ => True
+     end eq_refl}.
+Next Obligation. intros K φ Γ _ _ Heq ? ? ?. exact Heq. Defined.
+Next Obligation. intros K φ Γ _ _ Heq ? ?. exact Heq. Defined.
+
+
 (** The function [Proof_tree_dec] computes a proof tree of a sequent, if there is one, or produces a proof that there is none.
    The proof is performed by induction on the  well-ordering or pointed environments and tries to apply
    all the sequent rules to reduce the weight of the environment.
  *)
-Proposition Proof_tree_dec Γ φ :
+Proposition Proof_tree_dec {K : Kind} Γ φ :
   {_ : list_to_set_disj Γ ⊢ φ & True} + {forall H : list_to_set_disj  Γ ⊢ φ, False}.
 Proof.
 (* duplicate *)
@@ -79,8 +112,8 @@ destruct HAndL as [(ψ1 & ψ2 & Hin)|HAndL].
 { destruct (Hind (ψ1 :: ψ2 :: rm (And ψ1 ψ2) Γ) φ) as [[Hp' _] | Hf]. order_tac.
   - left. eexists; trivial. apply elem_of_list_to_set_disj in Hin.  
     exhibit Hin 0.
-    rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm _ _)) _ _ eq_refl).
-    apply AndL. peapply Hp'.
+    rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm Γ _)) _ _ eq_refl).
+    apply AndL. exch 0. peapply Hp'.
  - right. intro Hf'. apply Hf.
    rw (symmetry (list_to_set_disj_env_add (ψ2 :: rm (And ψ1 ψ2) Γ) ψ1)) 0.
    rw (symmetry (list_to_set_disj_env_add (rm (And ψ1 ψ2) Γ) ψ2)) 1.
@@ -113,7 +146,7 @@ destruct HOrL as [(ψ1 & ψ2 & Hin)|HOrL].
   destruct (Hind (ψ1 :: rm (Or ψ1 ψ2) Γ) φ) as [[Hp1 _] | Hf]. order_tac.
   - destruct (Hind (ψ2 :: rm (Or ψ1 ψ2) Γ) φ) as [[Hp2 _] | Hf]. order_tac.
     + left. eexists; trivial. exhibit Hin 0.
-         rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm _ _)) _ _ eq_refl).
+         rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm Γ _)) _ _ eq_refl).
          apply OrL. peapply Hp1. peapply Hp2.
     + right; intro Hf'. assert(Hf'' :list_to_set_disj (rm (Or ψ1 ψ2) Γ) • Or ψ1 ψ2 ⊢ φ). {
           rw (symmetry (list_to_set_disj_rm Γ(Or ψ1 ψ2))) 1.
@@ -224,7 +257,7 @@ assert(HOrR1 : {φ1 & {φ2 & {Hp : (list_to_set_disj Γ ⊢ φ1) & φ = (Or φ1 
 {
   destruct φ. 4: { destruct (Hind Γ φ1)as [[Hp _]|Hf]. order_tac.
   - left. do 3 eexists; eauto.
-  - right. intros ? ? Hp Heq. inversion Heq. subst. tauto.
+  - right. intros ? ? Hp Heq. dependent destruction Heq. tauto.
   }
   all: right; auto with *.
 }
@@ -235,7 +268,7 @@ assert(HOrR2 : {φ1 & {φ2 & {Hp : (list_to_set_disj Γ ⊢ φ2) & φ = (Or φ1 
 {
   destruct φ. 4: { destruct (Hind Γ φ2)as [[Hp _]|Hf]. order_tac.
   - left. do 3 eexists; eauto.
-  - right. intros ? ? Hp Heq. inversion Heq. subst. tauto.
+  - right. intros ? ? Hp Heq. dependent destruction Heq. tauto.
   }
   all: right; auto with *.
 }
@@ -243,26 +276,31 @@ assert(HOrR2 : {φ1 & {φ2 & {Hp : (list_to_set_disj Γ ⊢ φ2) & φ = (Or φ1 
 (* OrR2 *)
 destruct HOrR2 as [(φ1 & φ2 & Hp & Heq)| HOrR2 ].
 { subst. left. eexists; trivial. apply OrR2, Hp. }
-assert(HBoxR : {φ' & {Hp : (⊗ (list_to_set_disj Γ) • □ φ' ⊢ φ') & φ = (□ φ')}} +
-                       {∀ φ', ∀ (H : ⊗ (list_to_set_disj Γ) • □ φ' ⊢ φ'), φ = (□ φ') -> False}).
+assert(HBoxR : HBoxR_tree_spec φ Γ).
 {
   destruct φ. 6: { destruct (Hind  ((□ φ) :: map open_box Γ) φ)as [[Hp _]|Hf]. order_tac.
-  - left. do 2 eexists; eauto. l_tac. exact Hp.
-  - right. intros ? Hp Heq. inversion Heq. subst. apply Hf.
+  - assert(Heq : Modal = Modal) by trivial.
+    left. exists Heq. exists φ. l_tac. unfold M_inj.
+    repeat rewrite <- Eqdep.EqdepTheory.eq_rect_eq. eexists; eauto.
+  - right. intros φ' Hp Heq.
+    repeat rewrite <- Eqdep.EqdepTheory.eq_rect_eq in Heq.
+    inversion Heq. subst. apply Hf.
      rw (symmetry (list_to_set_disj_env_add (map open_box Γ) (□ φ'))) 0.
      rewrite <- list_to_set_disj_open_boxes. exact Hp.
   }
-  all: right; auto with *.
+  all: unfold HBoxR_tree_spec; destruct K; trivial; right; auto with *.
 }
 
 (* BoxR *)
-destruct HBoxR as [(φ' & Hp & Heq)| HBoxR ].
+destruct HBoxR as [(HModal & φ' & Hp & Heq)| HBoxR ].
 { left. subst. eexists; trivial. apply BoxR, Hp. }
+simpl in HBoxR.
 assert(Hempty: ∀ (Δ : env) φ,((Δ • φ) = ∅) -> False).
 {
   intros Δ θ Heq. assert (Hm:= multiplicity_empty θ).
   unfold base.empty in *.
-  rewrite <- Heq, union_mult, singleton_mult_in in Hm by trivial. lia.
+  rewrite <- Heq, union_mult in Hm.
+  setoid_rewrite (singleton_mult_in θ θ) in Hm. lia. reflexivity.
 }
 
 (* non invertible left rules *)
@@ -292,10 +330,10 @@ assert(HImpLImp : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & {φ3 &{H2312 : ((
           + left. repeat eexists; try l_tac; eauto. ms.
           + right; intros φ1 φ2 φ3 Hp1' Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf''. peapply Hp2.
+               dependent destruction Heq''. apply Hf''. peapply Hp2.
       - right; intros φ1 φ2 φ3 Hp1 Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf'. peapply Hp1.
+               dependent destruction Heq''. apply Hf'. peapply Hp1.
         }
         all: (right; intros φ1 φ2 φ3 Hp1 Hp2 He; apply elem_of_list_In in He; destruct He as [Heq''| Hin];
      [discriminate|apply elem_of_list_In in Hin; eapply Hf; eauto]).
@@ -304,20 +342,17 @@ destruct (HImpLImp Γ [] (app_nil_l _)) as [(φ1 & φ2 & φ3 & Hp1 & Hp2 & Hin)|
 { apply elem_of_list_to_set_disj in Hin.
   left. eexists; trivial. exhibit Hin 0. rw (list_to_set_disj_rm Γ(Implies (Implies φ1 φ2) φ3)) 1.
   apply ImpLImp; assumption.
-} 
+}
 
 (* ImpLBox *)
-assert(HImpLBox : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & {H2312 : ((⊗(list_to_set_disj ((rm (Implies (□ φ1) φ2) Γ))) • □ φ1 • φ2) ⊢φ1)
-                                          & {H3: (list_to_set_disj (rm (Implies (□ φ1) φ2) Γ) • φ2 ⊢ φ) & (Implies (□ φ1) φ2) ∈ Γ2}}}} +
-    {∀ φ1 φ2 (_ : ((⊗ (list_to_set_disj ((rm (Implies (□ φ1) φ2) Γ))) • □ φ1 • φ2) ⊢φ1))
-                              (_: list_to_set_disj (rm (Implies (□ φ1) φ2) Γ) • φ2 ⊢ φ),
-                               Implies (□ φ1) φ2 ∈ Γ2 → False}).
+assert(HImpLBox : HImpLBox_tree_spec φ Γ).
 {
-  induction Γ2 as [|θ Γ2]; intros Γ1 Heq.
-  - right. intros φ1 φ2 _ _ Hin. inversion Hin.
+  unfold HImpLBox_tree_spec. induction Γ2 as [|θ Γ2]; intros Γ1 Heq.
+  - right. destruct K; trivial. intros φ1 φ2 _ _ Hin. inversion Hin.
   - assert(Heq' : (Γ1 ++ [θ]) ++ Γ2 = Γ) by (subst; auto with *).
-    destruct (IHΓ2 (Γ1 ++  [θ]) Heq') as [(φ1 & φ2 & Hp1 & Hp2 & Hin)|Hf].
-   + left. repeat eexists; eauto. now right.
+    destruct (IHΓ2 (Γ1 ++  [θ]) Heq') as [(HModal & φ1 & φ2 & Hp1 & Hp2 & Hin)|Hf].
+   + left. exists HModal. repeat eexists; eauto.
+     unfold M_inj. subst. rewrite <- Eqdep.EqdepTheory.eq_rect_eq. now right.
    + destruct θ.
         5: destruct θ1.
         10 : {
@@ -328,21 +363,24 @@ assert(HImpLBox : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & {H2312 : ((⊗(li
         - destruct (Hind  (θ2 :: rm (Implies (□ θ1) θ2) Γ) φ) as [[Hp2 _] | Hf''].
           + order_tac. rewrite <- Permutation_middle. unfold rm.
               destruct form_eq_dec; [|tauto]. order_tac.
-          + left. repeat eexists; repeat l_tac; eauto. ms.
+          + left. exists eq_refl. repeat eexists; repeat l_tac; eauto. ms.
           + right; intros φ1 φ2 Hp1' Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf''. peapply Hp2.
+               dependent destruction Heq''. apply Hf''. peapply Hp2.
       - right; intros φ1 φ2 Hp1 Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf'.
+               dependent destruction Heq''. subst. apply Hf'.
              (erewrite proper_Provable;  [| |reflexivity]);  [eapply Hp1|].
-             repeat rewrite <- ?list_to_set_disj_env_add, list_to_set_disj_open_boxes. trivial.
+             repeat rewrite <- ?list_to_set_disj_env_add, list_to_set_disj_open_boxes.
+             unfold M_inj. subst. rewrite <- Eqdep.EqdepTheory.eq_rect_eq. trivial.
         }
-        all: (right; intros φ1 φ2 Hp1 Hp2 He; apply elem_of_list_In in He; destruct He as [Heq''| Hin];
-     [discriminate|apply elem_of_list_In in Hin; eapply Hf; eauto]).
+        all: (right ; try destruct K; trivial; intros φ1 φ2 Hp1 Hp2 He;
+              apply elem_of_list_In in He; destruct He as [Heq''| Hin];
+              [discriminate|apply elem_of_list_In in Hin; eapply Hf; eauto]).
 }
-destruct (HImpLBox Γ [] (app_nil_l _)) as [(φ1 & φ2 & Hp1 & Hp2 & Hin)|HfImpLBox].
+destruct (HImpLBox Γ [] (app_nil_l _)) as [(HModal & φ1 & φ2 & Hp1 & Hp2 & Hin)|HfImpLBox].
 { apply elem_of_list_to_set_disj in Hin.
+  unfold M_inj in Hin. subst. rewrite <- Eqdep.EqdepTheory.eq_rect_eq in Hin.
   left. eexists; trivial. exhibit Hin 0. rw (list_to_set_disj_rm Γ(Implies (□ φ1) φ2)) 1.
   apply ImpBox; assumption.
 }
@@ -354,10 +392,12 @@ Ltac eqt := match goal with | H : (_ • ?φ) = list_to_set_disj ?Γ |- _ =>
   let Heq := fresh "Heq" in assert(Heq := H);
   assert(Hinφ : φ ∈ Γ) by (apply elem_of_list_to_set_disj; setoid_rewrite <- H; ms);
   apply env_equiv_eq, env_add_inv', symmetry in Heq; rewrite list_to_set_disj_rm in Heq end.
-intro Hp. inversion Hp; subst; try eqt; eauto 2.
+intro Hp. dependent destruction Hp; subst; try eqt; eauto 2.
 - eapply HAndR; eauto.
 - eapply HImpR; eauto.
-- eapply HImpLVar; eauto. apply elem_of_list_to_set_disj. setoid_rewrite <- H; ms.
+- eapply HImpLVar; eauto. apply elem_of_list_to_set_disj.
+  match goal with H : _ = list_to_set_disj Γ |- _ => setoid_rewrite <- H end.
+  ms.
 - eapply HfImpl; eauto.
   + now rw Heq 1.
   + now rw Heq 1.
@@ -367,10 +407,36 @@ intro Hp. inversion Hp; subst; try eqt; eauto 2.
 Defined.
 
 
+Local Program Definition HBoxR_spec {K : Kind} (φ: form) (Γ : list form) := 
+  {Heq : K = Modal &
+   {φ' &
+   exists (Hp : ⊗ (list_to_set_disj (M_inj Heq Γ)) • □ φ' ⊢ φ'), φ = (□ φ')}}
+ + {match K as K' return (K = K' → Prop) with
+    | Modal => fun Heq => ∀ φ', ∀ (H : ⊗ (list_to_set_disj (M_inj Heq Γ)) • □ φ' ⊢ φ'), φ = (□ φ') -> False
+    | _=> fun _ => True end eq_refl}.
+Next Obligation. intros K φ Γ Heq _ _. exact (symmetry Heq). Defined.
+Next Obligation. intros K φ Γ Heq _ _. exact (symmetry Heq). Defined.
+
+Local Program Definition HImpLBox_spec {K : Kind} (φ: form) (Γ : list form) :=
+  ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ ->
+    {Heq : K = Modal & {φ1 & {φ2 
+      & exists _ : (⊗(list_to_set_disj ((rm (Implies (□ φ1) φ2) (M_inj Heq Γ)))) • □ φ1 • φ2) ⊢φ1,
+        exists _ : (list_to_set_disj (rm (Implies (□ φ1) φ2) (M_inj Heq Γ)) : @env Modal) • φ2 ⊢ φ,
+        Implies (□ φ1) φ2 ∈ M_inj Heq Γ2}}}
+  + {match K as K' return (K = K' → Prop) with
+     | Modal => fun Heq => ∀ φ1 φ2 (_ : ((⊗ (list_to_set_disj ((rm (Implies (□ φ1) φ2) (M_inj Heq Γ)))) • □ φ1 • φ2) ⊢φ1))
+             (_: (list_to_set_disj (rm (Implies (□ φ1) φ2) (M_inj Heq Γ)) : @env Modal) • φ2 ⊢ φ),
+             Implies (□ φ1) φ2 ∈ M_inj Heq Γ2 → False
+     | _ => fun _ => True
+     end eq_refl}.
+Next Obligation. intros K φ Γ _ _ Heq ? ? ?. exact Heq. Defined.
+Next Obligation. intros K φ Γ _ _ Heq ? ?. exact Heq. Defined.
+
+
 (** The function [Provable_dec] decides whether a sequent is provable.
    The proof is essentially the same as the definition of [Proof_tree_dec].
  *)
-Proposition Provable_dec Γ φ :
+Proposition Provable_dec {K : Kind} Γ φ :
   (exists _ : list_to_set_disj Γ ⊢ φ, True) + (forall H : list_to_set_disj  Γ ⊢ φ, False).
 Proof.
 remember (Γ, φ) as pe.
@@ -403,7 +469,7 @@ destruct HAndL as [(ψ1 & ψ2 & Hin)|HAndL].
 { destruct (Hind (ψ1 :: ψ2 :: rm (And ψ1 ψ2) Γ) φ) as [Hp' | Hf]. order_tac.
   - left. destruct Hp' as [Hp' _]. eexists; trivial. apply elem_of_list_to_set_disj in Hin.  
     exhibit Hin 0.
-    rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm _ _)) _ _ eq_refl).
+    rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm Γ _)) _ _ eq_refl).
     apply AndL. peapply Hp'.
  - right. intro Hf'. apply Hf.
    rw (symmetry (list_to_set_disj_env_add (ψ2 :: rm (And ψ1 ψ2) Γ) ψ1)) 0.
@@ -513,7 +579,7 @@ destruct HOrL as [(ψ1 & ψ2 & Hin)|HOrL].
   destruct (Hind (ψ1 :: rm (Or ψ1 ψ2) Γ) φ) as [Hp1| Hf]. order_tac.
   - destruct (Hind (ψ2 :: rm (Or ψ1 ψ2) Γ) φ) as [Hp2| Hf]. order_tac.
     + left. destruct Hp1 as [Hp1 _]. destruct Hp2 as [Hp2 _]. eexists; trivial. exhibit Hin 0.
-         rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm _ _)) _ _ eq_refl).
+         rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm Γ _)) _ _ eq_refl).
          apply OrL. peapply Hp1. peapply Hp2.
     + right; intro Hf'. assert(Hf'' :list_to_set_disj (rm (Or ψ1 ψ2) Γ) • Or ψ1 ψ2 ⊢ φ). {
           rw (symmetry (list_to_set_disj_rm Γ(Or ψ1 ψ2))) 1.
@@ -532,7 +598,7 @@ assert(HOrR1 : {φ1 & {φ2 & (exists (_ : list_to_set_disj Γ ⊢ φ1), φ = (Or
 {
   destruct φ. 4: { destruct (Hind Γ φ1)as [Hp|Hf]. order_tac.
   - left. do 2 eexists. destruct Hp as [Hp _]. eexists; eauto.
-  - right. intros ? ? Hp Heq. inversion Heq. subst. tauto.
+  - right. intros ? ? Hp Heq. dependent destruction Heq. subst. tauto.
   }
   all: right; auto with *.
 }
@@ -543,30 +609,30 @@ assert(HOrR2 : {φ1 & {φ2 & exists (_ : list_to_set_disj Γ ⊢ φ2), φ = (Or 
 {
   destruct φ. 4: { destruct (Hind Γ φ2)as [Hp|Hf]. order_tac.
   - left. do 2 eexists. destruct Hp as [Hp _]; eauto.
-  - right. intros ? ? Hp Heq. inversion Heq. subst. tauto.
+  - right. intros ? ? Hp Heq. dependent destruction Heq. subst. tauto.
   }
   all: right; auto with *.
 }
 destruct HOrR2 as [(φ1 & φ2 & Hp)| HOrR2 ].
 { left. destruct Hp as [Hp Heq]. subst. eexists; trivial. apply OrR2, Hp. }
-assert(HBoxR : {φ' & exists (_ : (⊗ (list_to_set_disj Γ) • □ φ' ⊢ φ')),  φ = (□ φ')} +
-                       {∀ φ', ∀ (H : ⊗ (list_to_set_disj Γ) • □ φ' ⊢ φ'), φ = (□ φ') -> False}).
+assert(HBoxR : HBoxR_spec φ Γ).
 {
   destruct φ. 6: { destruct (Hind  ((□ φ) :: map open_box Γ) φ)as [Hp|Hf]. order_tac.
-  - left. eexists. destruct Hp as [Hp _]. eexists; eauto. l_tac. exact Hp.
+  - left. exists eq_refl. eexists. destruct Hp as [Hp _]. eexists; eauto. l_tac. exact Hp.
   - right. intros ? Hp Heq. inversion Heq. subst. apply Hf.
      rw (symmetry (list_to_set_disj_env_add (map open_box Γ) (□ φ'))) 0.
      rewrite <- list_to_set_disj_open_boxes. exact Hp.
   }
-  all: right; auto with *.
+  all: unfold HBoxR_spec; destruct K; trivial; right; auto with *.
 }
-destruct HBoxR as [(φ' & Hp)| HBoxR ].
+destruct HBoxR as [(HModal & φ' & Hp)| HBoxR ].
 { left. destruct Hp as [Hp Heq]. subst. eexists; trivial. apply BoxR, Hp. }
 assert(Hempty: ∀ (Δ : env) φ,((Δ • φ) = ∅) -> False).
 {
   intros Δ θ Heq. assert (Hm:= multiplicity_empty θ).
   unfold base.empty in *.
-  rewrite <- Heq, union_mult, singleton_mult_in in Hm by trivial. lia.
+  rewrite <- Heq, union_mult in Hm.
+  setoid_rewrite (singleton_mult_in θ θ) in Hm; trivial. lia.
 }
 (* non invertible left rules *)
 assert(HImpLImp : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & {φ3 & exists (_ : (list_to_set_disj (rm (Implies (Implies φ1 φ2) φ3) Γ) • (Implies φ2 φ3)) ⊢ (Implies φ1 φ2)),
@@ -594,10 +660,10 @@ assert(HImpLImp : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & {φ3 & exists (_ 
               eexists; try l_tac; eauto. ms.
           + right; intros φ1 φ2 φ3 Hp1' Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf''. peapply Hp2.
+               dependent destruction Heq''. apply Hf''. peapply Hp2.
       - right; intros φ1 φ2 φ3 Hp1 Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf'. peapply Hp1.
+               dependent destruction Heq''. apply Hf'. peapply Hp1.
         }
         all: (right; intros φ1 φ2 φ3 Hp1 Hp2 He; apply elem_of_list_In in He; destruct He as [Heq''| Hin];
      [discriminate|apply elem_of_list_In in Hin; eapply Hf; eauto]).
@@ -609,18 +675,14 @@ destruct (HImpLImp Γ [] (app_nil_l _)) as [(φ1 & φ2 & φ3 & Hp1)|HfImpl].
   apply ImpLImp; assumption.
 } 
 (* ImpBox *)
-assert(HImpLBox : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & exists (_ : (⊗(list_to_set_disj ((rm (Implies (□ φ1) φ2) Γ))) • □ φ1 • φ2) ⊢φ1),
-                                          exists (_ : list_to_set_disj (rm (Implies (□ φ1) φ2) Γ) • φ2 ⊢ φ),
-                                          (Implies (□ φ1) φ2) ∈ Γ2}} +
-    {∀ φ1 φ2 (_ : ((⊗ (list_to_set_disj ((rm (Implies (□ φ1) φ2) Γ))) • □ φ1 • φ2) ⊢φ1))
-                              (_: list_to_set_disj (rm (Implies (□ φ1) φ2) Γ) • φ2 ⊢ φ),
-                               Implies (□ φ1) φ2 ∈ Γ2 → False}).
+assert(HImpLBox : HImpLBox_spec φ Γ).
 {
-  induction Γ2 as [|θ Γ2]; intros Γ1 Heq.
-  - right. intros φ1 φ2 _ _ Hin. inversion Hin.
+  unfold HImpLBox_spec. induction Γ2 as [|θ Γ2]; intros Γ1 Heq.
+  - right. destruct K; trivial. intros φ1 φ2 _ _ Hin. inversion Hin.
   - assert(Heq' : (Γ1 ++ [θ]) ++ Γ2 = Γ) by (subst; auto with *).
-    destruct (IHΓ2 (Γ1 ++  [θ]) Heq') as [(φ1 & φ2 & Hp1)|Hf].
-   + left. do 2 eexists. destruct Hp1 as (Hp1 & Hp2 & Hin). do 2 (eexists; eauto). now right.
+    destruct (IHΓ2 (Γ1 ++  [θ]) Heq') as [(HModal & φ1 & φ2 & Hp1)|Hf].
+   + left. subst. exists eq_refl. do 2 eexists.
+     destruct Hp1 as (Hp1 & Hp2 & Hin). do 2 (eexists; eauto). now right.
    + destruct θ.
         5: destruct θ1.
         10 : {
@@ -631,32 +693,35 @@ assert(HImpLBox : ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ -> {φ1 & {φ2 & exists (_ : (⊗(
         - destruct (Hind  (θ2 :: rm (Implies (□ θ1) θ2) Γ) φ) as [Hp2| Hf''].
           + order_tac. rewrite <- Permutation_middle. unfold rm.
               destruct form_eq_dec; [|tauto]. order_tac.
-          + left. do 2 eexists. destruct Hp1 as [Hp1 _]. destruct Hp2 as [Hp2 _].
+          + left. exists eq_refl. do 2 eexists. destruct Hp1 as [Hp1 _]. destruct Hp2 as [Hp2 _].
                repeat eexists; repeat l_tac; eauto. ms.
           + right; intros φ1 φ2 Hp1' Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf''. peapply Hp2.
+               dependent destruction Heq''. apply Hf''. peapply Hp2.
       - right; intros φ1 φ2 Hp1 Hp2 He; apply elem_of_list_In in He;
                destruct He as [Heq''| Hin]; [|apply elem_of_list_In in Hin; eapply Hf; eauto].
-               inversion Heq''. subst. apply Hf'.
+               dependent destruction Heq''. apply Hf'.
              (erewrite proper_Provable;  [| |reflexivity]);  [eapply Hp1|].
              repeat rewrite <- ?list_to_set_disj_env_add, list_to_set_disj_open_boxes. trivial.
         }
-        all: (right; intros φ1 φ2 Hp1 Hp2 He; apply elem_of_list_In in He; destruct He as [Heq''| Hin];
-     [discriminate|apply elem_of_list_In in Hin; eapply Hf; eauto]).
+        all: (right; try destruct K; trivial; intros φ1 φ2 Hp1 Hp2 He;
+              apply elem_of_list_In in He; destruct He as [Heq''| Hin];
+             [discriminate|apply elem_of_list_In in Hin; eapply Hf; eauto]).
 }
-destruct (HImpLBox Γ [] (app_nil_l _)) as [(φ1 & φ2 & Hp1)|HfImpLBox].
+destruct (HImpLBox Γ [] (app_nil_l _)) as [(HModal & φ1 & φ2 & Hp1)|HfImpLBox].
 { left. destruct Hp1 as (Hp1 & Hp2 & Hin). eexists; trivial.
+ unfold M_inj in Hin. subst. rewrite <- Eqdep.EqdepTheory.eq_rect_eq in Hin.
   apply elem_of_list_to_set_disj in Hin. exhibit Hin 0.
   rw (list_to_set_disj_rm Γ(Implies (□ φ1) φ2)) 1.
   apply ImpBox; assumption.
 }
 clear Hind HImpLImp HImpLBox.
 right.
-intro Hp. inversion Hp; subst; try eqt; eauto 2.
+intro Hp. dependent destruction Hp; try eqt; eauto 2.
 - eapply HAndR; eauto.
 - eapply HImpR; eauto.
-- eapply HImpLVar; eauto. apply elem_of_list_to_set_disj. setoid_rewrite <- H; ms.
+- eapply HImpLVar; eauto. apply elem_of_list_to_set_disj.
+  match goal with H : _ = list_to_set_disj Γ |- _ => setoid_rewrite <- H end. ms.
 - eapply HfImpl; eauto.
   + now rw Heq 1.
   + now rw Heq 1.
@@ -667,7 +732,7 @@ Defined.
 
 Global Infix "⊢?" := Provable_dec (at level 80).
 
-Lemma Provable_dec_of_Prop Γ φ: (∃ _ : list_to_set_disj Γ ⊢ φ, True) -> (list_to_set_disj Γ ⊢ φ).
+Lemma Provable_dec_of_Prop {K : Kind} Γ φ: (∃ _ : list_to_set_disj Γ ⊢ φ, True) -> (list_to_set_disj Γ ⊢ φ).
 Proof.
 destruct (Proof_tree_dec Γ φ) as [[Hφ1' _] | Hf']. tauto.
 intros Hf. exfalso. destruct Hf as [Hf _]. tauto.

--- a/theories/iSL/DecisionProcedure.v
+++ b/theories/iSL/DecisionProcedure.v
@@ -13,7 +13,7 @@ Proof.
 intros x y Heq. subst y.
 induction 1; simpl; trivial.
 - case form_eq_dec; auto with *.
-- case form_eq_dec; auto with * ; 
+- case form_eq_dec; auto with * ;
    case form_eq_dec; auto with *. intros. apply Permutation_swap.
 - now rewrite IHPermutation1.
 Qed.
@@ -35,7 +35,7 @@ Defined.
 Local Definition M_inj {K : Kind} (Heq : K = Modal) (Γ : list form) :=
   eq_rect K (fun K => list form) Γ Modal Heq.
 
-Local Program Definition HBoxR_tree_spec {K : Kind} (φ: form) (Γ : list form) := 
+Local Program Definition HBoxR_tree_spec {K : Kind} (φ: form) (Γ : list form) :=
   {Heq : K = Modal &
    {φ' &
    {Hp : (⊗ (list_to_set_disj (M_inj Heq Γ)) • □ φ' ⊢ φ') & φ = (□ φ')}}}
@@ -47,7 +47,7 @@ Next Obligation. intros K φ Γ Heq _ _. exact (symmetry Heq). Defined.
 
 Local Program Definition HImpLBox_tree_spec {K : Kind} (φ: form) (Γ : list form) :=
   ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ ->
-    {Heq : K = Modal & {φ1 & {φ2 
+    {Heq : K = Modal & {φ1 & {φ2
       & {H2312 : ((⊗(list_to_set_disj ((rm (Implies (□ φ1) φ2) (M_inj Heq Γ)))) • □ φ1 • φ2) ⊢φ1)
         & {H3: ((list_to_set_disj (rm (Implies (□ φ1) φ2) (M_inj Heq Γ)) : @env Modal) • φ2 ⊢ φ)
         & (Implies (□ φ1) φ2) ∈ M_inj Heq Γ2}}}}}
@@ -110,7 +110,7 @@ assert(HAndL : {ψ1 & {ψ2 & (And ψ1 ψ2) ∈ Γ}} + {∀ ψ1 ψ2, (And ψ1 ψ2
 }
 destruct HAndL as [(ψ1 & ψ2 & Hin)|HAndL].
 { destruct (Hind (ψ1 :: ψ2 :: rm (And ψ1 ψ2) Γ) φ) as [[Hp' _] | Hf]. order_tac.
-  - left. eexists; trivial. apply elem_of_list_to_set_disj in Hin.  
+  - left. eexists; trivial. apply elem_of_list_to_set_disj in Hin.
     exhibit Hin 0.
     rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm Γ _)) _ _ eq_refl).
     apply AndL. exch 0. peapply Hp'.
@@ -172,13 +172,13 @@ destruct HAndR as [(φ1 & φ2 & Heq) | HAndR].
 }
 
 (* ImpLVar *)
-assert(HImpLVar : {p & {ψ & Var p ∈ Γ /\ (Implies (Var p) ψ) ∈ Γ}} + 
+assert(HImpLVar : {p & {ψ & Var p ∈ Γ /\ (Implies (Var p) ψ) ∈ Γ}} +
                                  {∀ p ψ, Var p ∈ Γ -> (Implies (Var p) ψ) ∈ Γ -> False}). {
   pose (fIp :=λ p θ, match θ with | Implies (Var q) _ => if decide (p = q) then true else false | _ => false end).
   pose (fp:= (fun θ => match θ with |Var p => if (exists_dec (fIp p) Γ) then true else false | _ => false end)).
   destruct (exists_dec fp Γ) as [(θ & Hin & Hθ) | Hf].
   - left. subst fp. destruct θ. 2-6: auto with *.
-    case exists_dec as [(ψ &Hinψ & Hψ)|] in Hθ; [|auto with *]. 
+    case exists_dec as [(ψ &Hinψ & Hψ)|] in Hθ; [|auto with *].
     unfold fIp in Hψ. destruct ψ.  1-4, 6: auto with *.
     destruct ψ1. 2-6: auto with *. case decide in Hψ; [|auto with *].
     subst. apply elem_of_list_In in Hinψ, Hin.
@@ -407,7 +407,7 @@ intro Hp. dependent destruction Hp; subst; try eqt; eauto 2.
 Defined.
 
 
-Local Program Definition HBoxR_spec {K : Kind} (φ: form) (Γ : list form) := 
+Local Program Definition HBoxR_spec {K : Kind} (φ: form) (Γ : list form) :=
   {Heq : K = Modal &
    {φ' &
    exists (Hp : ⊗ (list_to_set_disj (M_inj Heq Γ)) • □ φ' ⊢ φ'), φ = (□ φ')}}
@@ -419,7 +419,7 @@ Next Obligation. intros K φ Γ Heq _ _. exact (symmetry Heq). Defined.
 
 Local Program Definition HImpLBox_spec {K : Kind} (φ: form) (Γ : list form) :=
   ∀Γ2 Γ1, Γ1 ++ Γ2 = Γ ->
-    {Heq : K = Modal & {φ1 & {φ2 
+    {Heq : K = Modal & {φ1 & {φ2
       & exists _ : (⊗(list_to_set_disj ((rm (Implies (□ φ1) φ2) (M_inj Heq Γ)))) • □ φ1 • φ2) ⊢φ1,
         exists _ : (list_to_set_disj (rm (Implies (□ φ1) φ2) (M_inj Heq Γ)) : @env Modal) • φ2 ⊢ φ,
         Implies (□ φ1) φ2 ∈ M_inj Heq Γ2}}}
@@ -467,7 +467,7 @@ assert(HAndL : {ψ1 & {ψ2 & (And ψ1 ψ2) ∈ Γ}} + {∀ ψ1 ψ2, (And ψ1 ψ2
 }
 destruct HAndL as [(ψ1 & ψ2 & Hin)|HAndL].
 { destruct (Hind (ψ1 :: ψ2 :: rm (And ψ1 ψ2) Γ) φ) as [Hp' | Hf]. order_tac.
-  - left. destruct Hp' as [Hp' _]. eexists; trivial. apply elem_of_list_to_set_disj in Hin.  
+  - left. destruct Hp' as [Hp' _]. eexists; trivial. apply elem_of_list_to_set_disj in Hin.
     exhibit Hin 0.
     rewrite (proper_Provable _ _ (equiv_disj_union_compat_r (list_to_set_disj_rm Γ _)) _ _ eq_refl).
     apply AndL. peapply Hp'.
@@ -487,13 +487,13 @@ destruct HImpR as [(φ1 & φ2 & Heq) | HImpR].
   - left. destruct Hp1 as [Hp1 _]. eexists; trivial. apply ImpR. peapply Hp1.
   - right. intro Hf. apply H1. apply ImpR_rev in Hf. peapply Hf.
 }
-assert(HImpLVar : {p & {ψ & Var p ∈ Γ /\ (Implies (Var p) ψ) ∈ Γ}} + 
+assert(HImpLVar : {p & {ψ & Var p ∈ Γ /\ (Implies (Var p) ψ) ∈ Γ}} +
                                  {∀ p ψ, Var p ∈ Γ -> (Implies (Var p) ψ) ∈ Γ -> False}). {
   pose (fIp :=λ p θ, match θ with | Implies (Var q) _ => if decide (p = q) then true else false | _ => false end).
   pose (fp:= (fun θ => match θ with |Var p => if (exists_dec (fIp p) Γ) then true else false | _ => false end)).
   destruct (exists_dec fp Γ) as [(θ & Hin & Hθ) | Hf].
   - left. subst fp. destruct θ. 2-6: auto with *.
-    case exists_dec as [(ψ &Hinψ & Hψ)|] in Hθ; [|auto with *]. 
+    case exists_dec as [(ψ &Hinψ & Hψ)|] in Hθ; [|auto with *].
     unfold fIp in Hψ. destruct ψ.  1-4, 6: auto with *.
     destruct ψ1. 2-6: auto with *. case decide in Hψ; [|auto with *].
     subst. apply elem_of_list_In in Hinψ, Hin.
@@ -673,7 +673,7 @@ destruct (HImpLImp Γ [] (app_nil_l _)) as [(φ1 & φ2 & φ3 & Hp1)|HfImpl].
   apply elem_of_list_to_set_disj in Hin. exhibit Hin 0.
   rw (list_to_set_disj_rm Γ(Implies (Implies φ1 φ2) φ3)) 1.
   apply ImpLImp; assumption.
-} 
+}
 (* ImpBox *)
 assert(HImpLBox : HImpLBox_spec φ Γ).
 {

--- a/theories/iSL/Environments.v
+++ b/theories/iSL/Environments.v
@@ -383,7 +383,7 @@ Proof.
 unfold open_boxes.
 assert (HH := gmultiset_elements_singleton φ).
 unfold elements, base.singletonMS, singletonMS, base.singleton, Environments.singleton in *.
-rewrite HH. simpl. unfold base.singletonMS, disj_union, empty. 
+rewrite HH. simpl. unfold base.singletonMS, disj_union, empty.
 apply gmultiset_disj_union_right_id.
 Qed.
 
@@ -451,7 +451,7 @@ Lemma is_not_box_open_box φ : is_box φ = false -> (⊙φ) = φ.
 Proof. unfold is_box. dependent destruction φ; simpl; intuition. discriminate. Qed.
 
 Lemma open_boxes_spec' Γ φ :
-    {_ : φ ∈ Γ & is_box φ = false} 
+    {_ : φ ∈ Γ & is_box φ = false}
   + {HK : K = Modal & (□ f_inj HK φ) ∈ f_inj HK Γ} -> φ ∈ open_boxes Γ.
 Proof.
 intros [[Hin Heq] | [HK Hin]];

--- a/theories/iSL/Environments.v
+++ b/theories/iSL/Environments.v
@@ -238,7 +238,6 @@ unfold singletonMS, base.singletonMS in HH.
 unfold base.singleton, Environments.singleton. ms.
 Qed.
 
-(* TODO : global later? *)
 Hint Resolve in_difference : multiset.
 
 (* could be used in disj_inv *)

--- a/theories/iSL/Formulas.v
+++ b/theories/iSL/Formulas.v
@@ -27,7 +27,7 @@ Inductive form : Kind -> Type :=
 Arguments form {_}.
 Arguments Var {_} _, _ _.
 
-Fixpoint occurs_in `{K : Kind} (x : variable) (φ : form) := 
+Fixpoint occurs_in `{K : Kind} (x : variable) (φ : form) :=
 match φ with
 | Var y => x = y
 | Bot => False
@@ -56,13 +56,13 @@ Global Instance form_top {K : Kind} : base.Top form := ⊤.
 Ltac solve_trivial_decision :=
   match goal with
   | |- Decision (?P) => apply _
-  | |- sumbool ?P (¬?P) => change (Decision P); apply _ 
+  | |- sumbool ?P (¬?P) => change (Decision P); apply _
   end.
 Ltac solve_decision :=
   unfold EqDecision; intros; first
     [ solve_trivial_decision
     | unfold Decision; decide equality; solve_trivial_decision ].
-    
+
 Global Instance variable_eq_dec : EqDecision variable.
 solve_decision. Defined.
 (** Formulas have decidable equality. *)

--- a/theories/iSL/Optimizations.v
+++ b/theories/iSL/Optimizations.v
@@ -783,7 +783,11 @@ assert(Hcut :
   induction Δ; simpl; split; intros ψ Hψ.
   - intro. apply Hψ.
   - split; trivial. intros φ Hin. contradict Hin. auto with *.
-  - intro Hall. case in_dec; intro; apply (fst IHΔ); auto with *.
+  - intro Hall. case in_dec; intro; apply (fst IHΔ).
+    + exact Hψ.
+    + auto with *.
+    + simpl. apply make_disj_sound_L, OrL; auto with *.
+    + auto with *.
   - case in_dec in Hψ; apply IHΔ in Hψ;
     destruct Hψ as [Hψ Hind].
     + split; trivial;  intros φ Hin; destruct (decide (φ = a)); auto 2 with *.

--- a/theories/iSL/Optimizations.v
+++ b/theories/iSL/Optimizations.v
@@ -7,7 +7,7 @@ Require Import Program Equality.
   We also introduce the Lindenbaum-Tarski preorder ≼ on formulas to formalize this.
   We rely on the decision procedure to decide when φ ≼ ψ holds.
   We then introduce the functions "make_impl", "make_conj" and "make_disj", which
-  perform obvious simplifications such as reducing φ ∧ ⊥ to ⊥ and φ ∨ ⊥ to φ. 
+  perform obvious simplifications such as reducing φ ∧ ⊥ to ⊥ and φ ∨ ⊥ to φ.
   We also formally verify that these reductions maintain equivalence and do not introduce any
   new variables.
 *)
@@ -52,8 +52,8 @@ match obviously_smaller φ ψ with
   | Gt => ψ
   | Eq => φ ∧ ψ
  end.
- 
- 
+
+
 Lemma occurs_in_choose_conj {K : Kind} v φ ψ :
   occurs_in v (choose_conj φ ψ) -> occurs_in v φ \/ occurs_in v ψ.
 Proof. unfold choose_conj; destruct obviously_smaller; simpl; intros; tauto. Qed.
@@ -76,7 +76,7 @@ match ψ in @form K' return (K' = K -> @form K) with
       then choose_conj φ (f_inj HK ψ2)
       else choose_conj φ ψ
   | _ => fun _ =>
-      match φ in @form K'' return (K'' = K -> @form K) with 
+      match φ in @form K'' return (K'' = K -> @form K) with
       | φ1 → φ2 => fun HK' =>
           if decide (obviously_smaller ψ (f_inj HK' φ1) = Lt)
           then choose_conj (f_inj HK' φ2) ψ
@@ -93,7 +93,7 @@ Proof.
 generalize ψ.
 induction φ; intro ψ0; dependent destruction ψ0;
 intro H; unfold make_conj in H; unfold choose_conj in H;
-repeat match goal with 
+repeat match goal with
     | H: occurs_in _  (if ?cond then _ else _) |- _ => case decide in H
     | H: occurs_in _ (match ?x with _ => _ end) |- _ => destruct x
     | |- _ => simpl; simpl in H; tauto
@@ -135,7 +135,7 @@ Proof.
 generalize ψ.
 induction φ; intro ψ0; dependent destruction ψ0;
 intro H; unfold make_disj in H; unfold choose_disj in H;
-repeat match goal with 
+repeat match goal with
     | H: occurs_in _  (if ?cond then _ else _) |- _ => case decide in H
     | H: occurs_in _ (match ?x with _ => _ end) |- _ => destruct x
     | |- _ => simpl; simpl in H; tauto
@@ -166,7 +166,7 @@ Infix "⇢" := make_impl (at level 66).
 Lemma occurs_in_choose_impl {K : Kind} v x y : occurs_in v (choose_impl x y) -> occurs_in v x ∨ occurs_in v y.
 Proof.
 intro H; unfold choose_impl in H; fold make_impl in H;
-repeat match goal with 
+repeat match goal with
     | H: occurs_in _  (if ?cond then _ else _) |- _ => case decide in H
     | H: occurs_in _ (match ?x with _ => _ end) |- _ => destruct x
     | |- _ => simpl; simpl in H; tauto
@@ -237,10 +237,10 @@ intro Hocc. apply Hcut in Hocc. simpl in Hocc. tauto.
 Qed.
 
 
-(** ** Correctness of optimizations 
+(** ** Correctness of optimizations
 
-    The following results show that the definitions of these functions are correct, in the sense that it does not make a difference for 
-    provability of a sequent whether one uses the literal conjunction, disjunction, and implication, or its optimized version. 
+    The following results show that the definitions of these functions are correct, in the sense that it does not make a difference for
+    provability of a sequent whether one uses the literal conjunction, disjunction, and implication, or its optimized version.
 *)
 
 
@@ -270,7 +270,7 @@ Proof.
 unfold obviously_smaller, Lindenbaum_Tarski_preorder.
 case ([φ] ⊢? ψ); intros Hp.
 - apply Provable_dec_of_Prop in Hp. split; intro.  peapply Hp. trivial.
-- split; intro Hf. 
+- split; intro Hf.
   + contradict Hf. case ([ψ] ⊢? φ); discriminate.
   + tauto.
 Qed.
@@ -285,7 +285,7 @@ case ([ψ] ⊢? φ); intro Hp; case ([φ] ⊢? ψ); intro Hp'; split; try discri
 - intros. apply Provable_dec_of_Prop in Hp.  peapply Hp.
 - intros _ Hf. destruct Hp'. contradict Hf. tauto.
 - intros _ Hf. destruct Hp'. contradict Hf. tauto.
-Qed.	
+Qed.
 
 
 (** Equivalence of the conjunction optimizations *)
@@ -343,7 +343,7 @@ Hint Unfold Lindenbaum_Tarski_preorder : proof.
 
 Local Ltac inj_tac := unfold f_inj in *; rewrite <- eq_rect_eq in *.
 
-Lemma make_conj_equiv_L {K : Kind} φ ψ φ' ψ' : 
+Lemma make_conj_equiv_L {K : Kind} φ ψ φ' ψ' :
   (φ ≼ φ') -> (ψ ≼ ψ') -> (φ ∧ ψ) ≼ φ' ⊼ ψ'.
 Proof.
 intros Hφ Hψ.
@@ -392,7 +392,7 @@ destruct ψ'; try (apply choose_conj_equiv_L; assumption); try inj_tac.
      * apply choose_conj_equiv_L; auto with proof.
 Qed.
 
-Lemma make_conj_equiv_R {K : Kind} φ ψ φ' ψ' : 
+Lemma make_conj_equiv_R {K : Kind} φ ψ φ' ψ' :
   (φ' ≼ φ) -> (ψ' ≼ ψ) -> φ' ⊼ ψ' ≼  φ ∧ ψ.
 Proof.
 intros Hφ Hψ.
@@ -407,7 +407,7 @@ destruct  ψ'; try inj_tac.
   + apply AndR.
     * apply AndL. now apply weakening.
     * apply (weak_cut _ ( ψ'1 ∧ ψ'2) _).
-      -- apply and_congruence; 
+      -- apply and_congruence;
          [now apply obviously_smaller_compatible_LT | apply generalised_axiom].
       -- assumption.
   + apply AndR.
@@ -426,7 +426,7 @@ Qed.
 
 Lemma specialised_weakening {K : Kind} Γ φ ψ : (φ ≼ ψ) ->  Γ•φ ⊢ ψ.
 Proof.
-intro H. 
+intro H.
 apply generalised_weakeningL.
 peapply H.
 Qed.
@@ -507,7 +507,7 @@ unfold choose_disj.
 case_eq (obviously_smaller φ' ψ'); intro Heq.
 - case_eq (obviously_smaller ψ' φ'); intro Heq'.
   + apply or_congruence; assumption.
-  + auto with proof. 
+  + auto with proof.
   + auto with proof.
 - apply OrL.
   + eapply weak_cut.
@@ -523,7 +523,7 @@ case_eq (obviously_smaller φ' ψ'); intro Heq.
     * apply generalised_axiom.
 Qed.
 
-Lemma choose_disj_equiv_R {K : Kind} φ ψ φ' ψ' : 
+Lemma choose_disj_equiv_R {K : Kind} φ ψ φ' ψ' :
   (φ' ≼ φ) -> (ψ' ≼ ψ) -> choose_disj φ' ψ' ≼  φ ∨ ψ.
 Proof.
 intros Hφ Hψ.
@@ -533,7 +533,7 @@ case_eq (obviously_smaller φ' ψ'); intro Heq;
 auto with proof.
 Qed.
 
-Lemma make_disj_equiv_L {K : Kind} φ ψ φ' ψ' : 
+Lemma make_disj_equiv_L {K : Kind} φ ψ φ' ψ' :
   (φ ≼ φ') -> (ψ ≼ ψ') -> (φ ∨ ψ) ≼ φ' ⊻ ψ'.
 Proof.
 intros Hφ Hψ.
@@ -554,19 +554,19 @@ destruct ψ'; try (apply choose_disj_equiv_L; assumption); try inj_tac.
 - case_eq (obviously_smaller φ' ψ'1); intro Heq.
   + now apply or_congruence.
   + apply OrL.
-    * eapply weak_cut. 
+    * eapply weak_cut.
       -- apply Hφ.
       -- apply OrR1. now apply obviously_smaller_compatible_LT.
     * assumption.
   + apply OrL.
     * now apply OrR1.
     * eapply weak_cut.
-      -- apply Hψ. 
+      -- apply Hψ.
       -- apply or_congruence; [apply obviously_smaller_compatible_GT; assumption| apply generalised_axiom].
 Qed.
 
 
-Lemma make_disj_equiv_R {K : Kind} φ ψ φ' ψ' : 
+Lemma make_disj_equiv_R {K : Kind} φ ψ φ' ψ' :
   (φ' ≼ φ) -> (ψ' ≼ ψ) -> φ' ⊻  ψ' ≼  φ ∨ ψ.
 Proof.
 intros Hφ Hψ.
@@ -659,7 +659,7 @@ repeat match goal with
 | H : is_negation _ _ |- _ =>  eapply additive_cut; [| exch 0; apply weakening, HP]; apply ImpR, exfalso; exch 0; auto with proof
 end; trivial; try (solve [eapply imp_cut; eauto]);
 try solve[apply weakening, (tautology_cut HP); trivial; try apply weak_cut with ⊥; auto with proof].
-- apply weakening, (tautology_cut HP); trivial. apply additive_cut with (φ := ⊤); auto with proof. 
+- apply weakening, (tautology_cut HP); trivial. apply additive_cut with (φ := ⊤); auto with proof.
 - eapply additive_cut with (φ :=  (φ → ψ)).
   + apply ImpR. exch 0. apply ImpL; auto with proof.
   + auto with proof.
@@ -702,7 +702,7 @@ Qed.
 
 Lemma make_impl_sound_R {K : Kind} Γ φ ψ: Γ ⊢ (φ → ψ) -> Γ ⊢ φ ⇢ ψ.
 Proof.
-revert φ. induction ψ; intros φ HP; simpl. 
+revert φ. induction ψ; intros φ HP; simpl.
 1-4, 6: now apply choose_impl_sound_R.
 apply IHψ2, ImpR, make_conj_sound_L, AndL, ImpR_rev, ImpR_rev, HP.
 Qed.
@@ -718,7 +718,7 @@ apply additive_cut with (φ1 ⇢ (φ2 → ψ)).
   apply ImpR. exch 0. apply ImpL.
   + apply weakening, generalised_axiom.
   + exch 0. apply weakening, make_impl_sound_L, generalised_axiom.
-- exch 0. apply weakening, HP. 
+- exch 0. apply weakening, HP.
 Qed.
 
 Global Hint Resolve make_impl_sound_L2: proof.
@@ -758,7 +758,7 @@ intro HP.
 apply additive_cut with (φ ⇢ ψ); [apply HP| apply make_impl_sound_L, generalised_axiom ].
 Qed.
 
-(** ** Generalized rules 
+(** ** Generalized rules
 
 In this section we prove that generalizations of or-left and and-right rules
 that take more than two formulas are admissible and invertible in the calculus
@@ -819,7 +819,7 @@ assert(Hcut : forall θ, ((Γ ⊢ θ) + (φ ∈ Δ)) -> Γ ⊢ foldl make_disj �
     + case in_dec; intro; apply IHΔ; right; tauto.
 }
 intro Hin. apply Hcut; now right.
-Qed.  
+Qed.
 
 (** *** Generalized AndR *)
 
@@ -898,7 +898,7 @@ Qed.
 Lemma conjunction_R {K : Kind} Δ: list_to_set_disj Δ ⊢ ⋀ Δ.
 Proof.
 apply conjunction_R1. intros φ Hφ. apply elem_of_list_to_set_disj in Hφ.
-exhibit Hφ 0. apply generalised_axiom. 
+exhibit Hφ 0. apply generalised_axiom.
 Qed.
 
 Lemma conjunction_L'' {K : Kind} Γ Δ ϕ:

--- a/theories/iSL/Order.v
+++ b/theories/iSL/Order.v
@@ -8,7 +8,7 @@ Definition env_weight {K : Kind} Γ :=
 
 Lemma env_weight_disj_union {K : Kind} Γ Δ :
   env_weight (Γ ++ Δ) = env_weight Γ +  env_weight Δ.
-Proof. 
+Proof.
 unfold env_weight. now rewrite map_app, list_sum_app.
 Qed.
 
@@ -99,7 +99,7 @@ Lemma env_order_equiv_right_compat {K : Kind} {Δ Δ' Δ'' }:
   Δ' ≡ₚ Δ'' ->
   (Δ ≺ Δ'') ->
   Δ ≺ Δ'.
-Proof. 
+Proof.
 unfold equiv, env_order, ltof, env_weight. intro Heq. rewrite Heq. trivial.
 Qed.
 
@@ -239,7 +239,7 @@ pose (pow5_gt_0 (Init.Nat.pred (weight φ))).
 lia.
 Qed.
 
-Lemma env_order_3 {K : Kind} Δ Δ' φ1 φ2 φ3 φ: 
+Lemma env_order_3 {K : Kind} Δ Δ' φ1 φ2 φ3 φ:
   weight φ1 < weight φ -> weight φ2 < weight φ -> weight φ3 < weight φ -> (Δ' ≼ Δ) ->
   Δ' • φ1 • φ2  • φ3 ≺ Δ • φ.
 Proof.
@@ -256,7 +256,7 @@ pose (pow5_gt_0 (Init.Nat.pred (weight φ))).
 lia.
 Qed.
 
-Lemma env_order_4 {K : Kind} Δ Δ' φ1 φ2 φ3 φ4 φ: 
+Lemma env_order_4 {K : Kind} Δ Δ' φ1 φ2 φ3 φ4 φ:
   weight φ1 < weight φ -> weight φ2 < weight φ -> weight φ3 < weight φ -> weight φ4 < weight φ ->
    (Δ' ≼ Δ) -> Δ' • φ1 • φ2  • φ3 • φ4 ≺ Δ • φ.
 Proof.
@@ -311,7 +311,7 @@ end.
 Lemma remove_env_order {K : Kind} Δ φ:  rm φ Δ ≼ Δ.
 Proof.
 unfold env_order_refl.
-induction Δ as [|ψ Δ]. trivial. 
+induction Δ as [|ψ Δ]. trivial.
 simpl. destruct form_eq_dec; repeat rewrite env_weight_add; lia.
 Qed.
 
@@ -356,7 +356,7 @@ Proof.
   apply Proper_elements, difference_singleton, Hin.
 Qed.
 
-Ltac prepare_order := 
+Ltac prepare_order :=
 repeat (apply env_order_add_compat);
 unfold pointed_env_order; subst; simpl; repeat rewrite open_boxes_add; try match goal with
 | Δ := _ |- _ => subst Δ; try prepare_order
@@ -369,7 +369,7 @@ unfold pointed_env_order; subst; simpl; repeat rewrite open_boxes_add; try match
     apply (env_order_equiv_right_compat (equiv_disj_union_compat_r(difference_singleton Γ ψ' H)))
 | H : ?ψ ∈ ?Γ |- ?Γ' ≺ (_ :: _ :: ?Γ) => let ψ' := (get_diff_form Γ') in
 apply (env_order_equiv_right_compat (equiv_disj_union_compat_r(equiv_disj_union_compat_r(difference_singleton Γ ψ' H)))) ||
-(eapply env_order_le_lt_trans; [| apply env_order_add_compat; 
+(eapply env_order_le_lt_trans; [| apply env_order_add_compat;
 eapply env_order_lt_le_trans; [| (apply env_order_refl_add; apply (remove_In_env_order_refl _ ψ'); try apply elem_of_list_In; trivial) ] ] )
 |H : ?a = _ |- context[?a] => rewrite H; try prepare_order
 end.
@@ -405,7 +405,7 @@ Global Hint Resolve weight_Box_1 : order.
 
 Ltac order_tac :=
 try unfold pointed_env_ms_order; prepare_order;
-repeat rewrite elements_env_add; 
+repeat rewrite elements_env_add;
 simpl; auto 10 with order;
 try (apply env_order_disj_union_compat_right; order_tac).
 

--- a/theories/iSL/Order.v
+++ b/theories/iSL/Order.v
@@ -1,56 +1,63 @@
 (** * Ordering *)
 Require Export ISL.Environments.
+Require Import Coq.Program.Equality.
 
 (* Note 3 or 4 would suffice for IPC ; iSL requires 5 *)
-Definition env_weight (Γ : list form) := list_sum (map (fun x => 5^ weight x) Γ).
+Definition env_weight {K : Kind} Γ :=
+  list_sum (map (fun x => 5^ weight x) Γ).
 
-Lemma env_weight_disj_union Γ Δ : env_weight (Γ ++ Δ) = env_weight Γ +  env_weight Δ.
+Lemma env_weight_disj_union {K : Kind} Γ Δ :
+  env_weight (Γ ++ Δ) = env_weight Γ +  env_weight Δ.
 Proof. 
 unfold env_weight. now rewrite map_app, list_sum_app.
 Qed.
 
 Notation "Δ '•' φ" := (cons φ Δ) : list_scope.
 
-Lemma env_weight_add Γ φ : env_weight (Γ • φ) = env_weight Γ +  (5 ^ weight φ).
+Lemma env_weight_add (K : Kind) Γ φ :
+  env_weight (Γ • φ) = env_weight Γ +  (5 ^ weight φ).
 Proof.
 unfold env_weight. simpl. lia.
 Qed.
 
 Global Hint Rewrite env_weight_add : order.
 
-Definition env_order := ltof (list form) env_weight.
+Definition env_order {K : Kind} := ltof _ env_weight.
 Infix "≺" := env_order (at level 150).
 
-Lemma env_weight_singleton (φ : form) : env_weight [ φ ] = 5 ^ weight φ.
+Lemma env_weight_singleton {K : Kind} (φ : form) :
+  env_weight [ φ ] = 5 ^ weight φ.
 Proof.
 unfold env_weight, ltof. simpl. lia.
 Qed.
 
-Lemma env_order_singleton (φ ψ : form) : weight φ < weight ψ -> [φ ] ≺ [ ψ ].
+Lemma env_order_singleton {K : Kind}  φ ψ :
+  weight φ < weight ψ -> [φ ] ≺ [ ψ ].
 Proof.
 intro Hw. unfold env_order, ltof. do 2 rewrite env_weight_singleton.
 apply Nat.pow_lt_mono_r. lia. trivial.
 Qed.
 
-Definition env_order_refl Δ Δ' :=  (env_weight Δ) ≤(env_weight Δ').
+Definition env_order_refl {K : Kind} Δ Δ' := (env_weight Δ) ≤(env_weight Δ').
 
 Global Notation "Δ ≼ Δ'" := (env_order_refl Δ Δ') (at level 150).
 
-Lemma env_order_env_order_refl Δ Δ' : env_order Δ Δ' -> env_order_refl Δ Δ'.
+Lemma env_order_env_order_refl {K : Kind} Δ Δ' :
+  env_order Δ Δ' -> env_order_refl Δ Δ'.
 Proof. unfold env_order, env_order_refl, ltof. lia. Qed.
 
 Global Hint Resolve env_order_env_order_refl: order.
 
-Lemma env_order_self Δ : Δ ≼ Δ.
+Lemma env_order_self {K : Kind} Δ : Δ ≼ Δ.
 Proof. unfold env_order_refl. trivial. Qed.
 
-Global Instance Proper_env_weight: Proper ((≡ₚ) ==> (=)) env_weight.
+Global Instance Proper_env_weight {K : Kind} : Proper ((≡ₚ) ==> (=)) env_weight.
 Proof.
 intros Γ Δ Heq. unfold env_weight. now rewrite Heq.
 Qed.
 
 
-Global Instance Proper_env_order_refl_env_weight:
+Global Instance Proper_env_order_refl_env_weight {K : Kind}:
   Proper ((env_order_refl) ==> le) env_weight.
 Proof. intros Γ Δ Hle. auto with *. Qed.
 
@@ -59,38 +66,36 @@ Global Hint Resolve Proper_env_order_refl_env_weight : order.
 Global Hint Unfold form_order : mset.
 
 
-Global Instance env_order_trans : Transitive env_order.
+Global Instance env_order_trans {K : Kind} : Transitive env_order.
 Proof. unfold env_order, env_weight, ltof. auto with *. Qed.
 
-Definition wf_env_order : well_founded env_order.
+Definition wf_env_order {K : Kind} : well_founded env_order.
 Proof. now apply well_founded_lt_compat with env_weight.
 Defined.
 
 (* We introduce a notion of "pointed" environment, which is simply
  * a pair (Δ, φ), where Δ is an environment and φ is a formula,
  * not necessarily an element of Δ.  *)
-Definition pointed_env := (list form * form)%type.
-
-
+Definition pointed_env {K : Kind} := (list (form) * form)%type.
 
 
 (* The order on pointed environments is given by considering the
  * environment order on the sum of Δ and {φ}. *)
-Definition pointed_env_order (pe1 : pointed_env) (pe2 : pointed_env) :=
+Definition pointed_env_order {K : Kind} (pe1 : pointed_env) (pe2 : pointed_env) :=
   env_order (fst pe1 • snd pe1 • snd pe1) (fst pe2 • snd pe2 •  snd pe2).
 
-Lemma wf_pointed_order : well_founded pointed_env_order.
+Lemma wf_pointed_order {K : Kind} : well_founded pointed_env_order.
 Proof. apply well_founded_ltof. Qed.
 
-Definition pointed_env_ms_order (Γφ Δψ : env * form) :=
+Definition pointed_env_ms_order {K : Kind} (Γφ Δψ : env * form) :=
   pointed_env_order (elements Γφ.1, Γφ.2) (elements Δψ.1, Δψ.2).
 
-Lemma wf_pointed_env_ms_order : well_founded pointed_env_ms_order.
+Lemma wf_pointed_env_ms_order {K : Kind}: well_founded pointed_env_ms_order.
 Proof. apply well_founded_ltof. Qed.
 
 Infix "≺·" := pointed_env_order (at level 150).
 
-Lemma env_order_equiv_right_compat {Δ Δ' Δ'' }:
+Lemma env_order_equiv_right_compat {K : Kind} {Δ Δ' Δ'' }:
   Δ' ≡ₚ Δ'' ->
   (Δ ≺ Δ'') ->
   Δ ≺ Δ'.
@@ -98,23 +103,28 @@ Proof.
 unfold equiv, env_order, ltof, env_weight. intro Heq. rewrite Heq. trivial.
 Qed.
 
-Lemma env_order_equiv_left_compat {Δ Δ' Δ'' }:
+Lemma env_order_equiv_left_compat {K : Kind} {Δ Δ' Δ'' }:
   Δ ≡ₚ Δ'' ->
   (Δ'' ≺ Δ') ->
   Δ ≺ Δ'.
 Proof. unfold equiv, env_order, ltof, env_weight. intro Heq. rewrite Heq. trivial. Qed.
 
 
-Global Instance Proper_env_order : Proper ((≡ₚ) ==> (≡ₚ) ==> (fun x y => x <-> y)) env_order.
-Proof. intros Δ1 Δ2 H12 Δ3 Δ4 H34; unfold equiv, env_order, ltof, env_weight.  rewrite H12, H34. tauto. Qed.
+Global Instance Proper_env_order {K : Kind}:
+  Proper ((≡ₚ) ==> (≡ₚ) ==> (fun x y => x <-> y)) env_order.
+Proof.
+  intros Δ1 Δ2 H12 Δ3 Δ4 H34; unfold equiv, env_order, ltof, env_weight.
+  rewrite H12, H34. tauto.
+Qed.
 
-Global Instance Proper_env_order_refl : Proper ((≡ₚ) ==> (≡ₚ) ==> (fun x y => x <-> y)) env_order_refl.
+Global Instance Proper_env_order_refl {K : Kind}:
+  Proper ((≡ₚ) ==> (≡ₚ) ==> (fun x y => x <-> y)) env_order_refl.
 Proof.
 intros Δ1 Δ2 H12 Δ3 Δ4 H34; unfold equiv, env_order, ltof, env_weight, env_order_refl.
 now rewrite H12, H34.
 Qed.
 
-Lemma env_order_1  Δ φ1 φ : weight φ1 < weight φ -> Δ • φ1 ≺ Δ • φ.
+Lemma env_order_1 {K : Kind} Δ φ1 φ : weight φ1 < weight φ -> Δ • φ1 ≺ Δ • φ.
 Proof.
 intros Hw.  unfold env_order, ltof. do 2 rewrite env_weight_add.
 apply Nat.add_lt_mono_l. apply Nat.pow_lt_mono_r. lia. trivial.
@@ -122,7 +132,8 @@ Qed.
 
 Local Hint Resolve Nat.pow_lt_mono_r : order.
 
-Lemma env_order_compat  Δ Δ' φ1 φ : weight φ1 < weight φ -> (Δ' ≼ Δ) -> Δ' • φ1 ≺ Δ • φ.
+Lemma env_order_compat {K : Kind} Δ Δ' φ1 φ :
+  weight φ1 < weight φ -> (Δ' ≼ Δ) -> Δ' • φ1 ≺ Δ • φ.
 Proof.
 intros.  unfold env_order, ltof. repeat rewrite env_weight_add.
 apply Nat.add_le_lt_mono; auto with *.
@@ -130,7 +141,8 @@ Qed.
 
 Global Hint Resolve env_order_compat : order.
 
-Lemma env_order_compat'  Δ Δ' φ1 φ : weight φ1 ≤ weight φ -> (Δ' ≺ Δ) -> Δ' • φ1 ≺ Δ • φ.
+Lemma env_order_compat' {K : Kind} Δ Δ' φ1 φ :
+  weight φ1 ≤ weight φ -> (Δ' ≺ Δ) -> Δ' • φ1 ≺ Δ • φ.
 Proof.
 intros.  unfold env_order, ltof. repeat rewrite env_weight_add.
 apply Nat.add_lt_le_mono; auto with *. now apply Nat.pow_le_mono_r.
@@ -138,19 +150,19 @@ Qed.
 
 Global Hint Resolve env_order_compat' : order.
 
-Lemma env_order_add_compat Δ Δ' φ : (Δ ≺ Δ') -> (Δ • φ) ≺ (Δ' • φ).
+Lemma env_order_add_compat {K : Kind} Δ Δ' φ : (Δ ≺ Δ') -> (Δ • φ) ≺ (Δ' • φ).
 Proof.
 unfold env_order, ltof. do 2 rewrite env_weight_add. lia.
 Qed.
 
 (* TODO: this is just a special case *)
-Lemma env_order_disj_union_compat_left Δ Δ' Δ'':
+Lemma env_order_disj_union_compat_left {K : Kind} Δ Δ' Δ'':
   (Δ ≺ Δ'') -> Δ ++ Δ' ≺ Δ'' ++ Δ'.
 Proof.
 unfold env_order, ltof. intro. do 2 rewrite env_weight_disj_union. lia.
 Qed.
 
-Lemma env_order_disj_union_compat_right Δ Δ' Δ'':
+Lemma env_order_disj_union_compat_right {K : Kind} Δ Δ' Δ'':
   (Δ ≺ Δ'') -> Δ' ++ Δ ≺ Δ' ++ Δ''.
 Proof.
 unfold env_order, ltof. repeat rewrite env_weight_disj_union. lia.
@@ -158,13 +170,13 @@ Qed.
 
 Global Hint Resolve env_order_disj_union_compat_right : order.
 
-Lemma env_order_disj_union_compat Δ Δ' Δ'' Δ''':
+Lemma env_order_disj_union_compat {K : Kind} Δ Δ' Δ'' Δ''':
   (Δ ≺ Δ'') -> (Δ' ≺ Δ''') -> Δ ++ Δ' ≺ Δ'' ++ Δ'''.
 Proof.
 unfold env_order, ltof. repeat rewrite env_weight_disj_union. lia.
 Qed.
 
-Lemma env_order_refl_disj_union_compat Δ Δ' Δ'' Δ''':
+Lemma env_order_refl_disj_union_compat {K : Kind} Δ Δ' Δ'' Δ''':
   (env_order_refl Δ Δ'') -> (env_order_refl Δ' Δ''') -> env_order_refl (Δ ++ Δ') (Δ'' ++ Δ''').
 Proof.
 unfold env_order_refl, env_order, ltof. repeat rewrite env_weight_disj_union.
@@ -174,33 +186,33 @@ Qed.
 Global Hint Resolve env_order_refl_disj_union_compat : order.
 
 Hint Unfold env_order_refl : order.
-Lemma env_order_disj_union_compat_strong_right Δ Δ' Δ'' Δ''':
+Lemma env_order_disj_union_compat_strong_right {K : Kind} Δ Δ' Δ'' Δ''':
   (Δ ≺ Δ'') -> (Δ' ≼ Δ''') -> Δ ++ Δ' ≺ Δ'' ++ Δ'''.
 Proof.
 intros Hlt Hle. unfold env_order_refl, env_order, ltof in *. do 2 rewrite env_weight_disj_union. lia.
 Qed.
 
-Lemma env_order_disj_union_compat_strong_left Δ Δ' Δ'' Δ''':
+Lemma env_order_disj_union_compat_strong_left {K : Kind} Δ Δ' Δ'' Δ''':
   (Δ ≼ Δ'') -> (Δ' ≺ Δ''') -> Δ ++ Δ' ≺ Δ'' ++ Δ'''.
 Proof.
 intros Hlt Hle. unfold env_order_refl, env_order, ltof in *. do 2 rewrite env_weight_disj_union. lia. Qed.
 
 Global Hint Resolve env_order_disj_union_compat_strong_left : order.
-Global Hint Rewrite elements_open_boxes : order.
+Global Hint Resolve elements_open_boxes : order.
 
-Lemma weight_open_box φ : weight (⊙ φ) ≤ weight φ.
-Proof. destruct φ; simpl; lia. Qed.
+Lemma weight_open_box {K : Kind} φ : weight (⊙ φ) ≤ weight φ.
+Proof. dependent destruction φ; simpl; lia. Qed.
 
-Lemma open_boxes_env_order Δ : (map open_box Δ) ≼ Δ.
+Lemma open_boxes_env_order {K : Kind} Δ : (map open_box Δ) ≼ Δ.
 Proof.
 unfold env_order_refl.
 induction Δ as [|φ Δ]; trivial.
-simpl. do 2 rewrite env_weight_add. destruct φ; simpl; lia.
+simpl. do 2 rewrite env_weight_add. dependent destruction φ; simpl; lia.
 Qed.
 
 Global Hint Resolve open_boxes_env_order : order.
 
-Lemma env_order_0 Δ φ: Δ ≺ Δ • φ.
+Lemma env_order_0 {K : Kind} Δ φ: Δ ≺ Δ • φ.
 Proof.
 unfold env_order, ltof. rewrite env_weight_add.
 apply Nat.lt_add_pos_r. transitivity (5 ^ 0). simpl. lia. apply Nat.pow_lt_mono_r. lia.
@@ -212,7 +224,7 @@ Proof. transitivity (5^0). simpl. lia. apply Nat.pow_le_mono_r; lia. Qed.
 
 Local Hint Resolve pow5_gt_0: order.
 
-Lemma env_order_2  Δ Δ' φ1 φ2 φ: weight φ1 < weight φ -> weight φ2 < weight φ ->
+Lemma env_order_2 {K : Kind} Δ Δ' φ1 φ2 φ: weight φ1 < weight φ -> weight φ2 < weight φ ->
   (Δ' ≼ Δ) -> Δ' • φ1 • φ2 ≺ Δ • φ.
 Proof.
 intros Hw1 Hw2 Hor.
@@ -228,7 +240,7 @@ pose (pow5_gt_0 (Init.Nat.pred (weight φ))).
 lia.
 Qed.
 
-Lemma env_order_3  Δ Δ' φ1 φ2 φ3 φ: 
+Lemma env_order_3 {K : Kind} Δ Δ' φ1 φ2 φ3 φ: 
   weight φ1 < weight φ -> weight φ2 < weight φ -> weight φ3 < weight φ -> (Δ' ≼ Δ) ->
   Δ' • φ1 • φ2  • φ3 ≺ Δ • φ.
 Proof.
@@ -245,7 +257,7 @@ pose (pow5_gt_0 (Init.Nat.pred (weight φ))).
 lia.
 Qed.
 
-Lemma env_order_4  Δ Δ' φ1 φ2 φ3 φ4 φ: 
+Lemma env_order_4 {K : Kind} Δ Δ' φ1 φ2 φ3 φ4 φ: 
   weight φ1 < weight φ -> weight φ2 < weight φ -> weight φ3 < weight φ -> weight φ4 < weight φ ->
    (Δ' ≼ Δ) -> Δ' • φ1 • φ2  • φ3 • φ4 ≺ Δ • φ.
 Proof.
@@ -262,13 +274,13 @@ pose (pow5_gt_0 (Init.Nat.pred (weight φ))).
 lia.
 Qed.
 
-Lemma env_order_cancel_right Δ Δ' φ:  (Δ ≺ Δ') -> Δ ≺ (Δ' • φ).
+Lemma env_order_cancel_right {K : Kind} Δ Δ' φ:  (Δ ≺ Δ') -> Δ ≺ (Δ' • φ).
 Proof. etransitivity; [|apply env_order_0].	 assumption. Qed.
 
-Lemma env_order_refl_add Δ Δ' φ: (Δ ≼ Δ') -> (Δ • φ) ≼ (Δ' • φ).
+Lemma env_order_refl_add {K : Kind} Δ Δ' φ: (Δ ≼ Δ') -> (Δ • φ) ≼ (Δ' • φ).
 Proof. unfold env_order_refl. do 2 rewrite env_weight_add. lia. Qed.
 
-Lemma env_order_refl_add' Δ Δ' φ φ': weight φ ≤ weight φ' -> (Δ ≼ Δ') -> (Δ • φ) ≼ (Δ' • φ').
+Lemma env_order_refl_add' {K : Kind} Δ Δ' φ φ': weight φ ≤ weight φ' -> (Δ ≼ Δ') -> (Δ • φ) ≼ (Δ' • φ').
 Proof. unfold env_order_refl. do 2 rewrite env_weight_add.
 intros. apply Nat.add_le_mono. lia. apply Nat.pow_le_mono_r; lia. Qed.
 
@@ -297,9 +309,7 @@ Ltac get_diff_env g := match g with
 | _ :: ?Γ => get_diff_env Γ
 end.
 
-Global Hint Rewrite open_boxes_remove : order.
-
-Lemma remove_env_order Δ φ:  rm φ Δ ≼ Δ.
+Lemma remove_env_order {K : Kind} Δ φ:  rm φ Δ ≼ Δ.
 Proof.
 unfold env_order_refl.
 induction Δ as [|ψ Δ]. trivial. 
@@ -308,7 +318,7 @@ Qed.
 
 Global Hint Resolve remove_env_order : order.
 
-Lemma remove_In_env_order_refl Δ φ:  In φ Δ -> rm φ Δ • φ ≼ Δ.
+Lemma remove_In_env_order_refl {K : Kind} Δ φ:  In φ Δ -> rm φ Δ • φ ≼ Δ.
 Proof.
 induction Δ as [|ψ Δ].
 - intro Hf; contradict Hf.
@@ -321,13 +331,13 @@ Qed.
 
 Global Hint Resolve remove_In_env_order_refl : order.
 
-Lemma env_order_lt_le_trans Γ Γ' Γ'' : (Γ ≺ Γ') -> (Γ' ≼ Γ'') -> Γ ≺ Γ''.
+Lemma env_order_lt_le_trans {K : Kind} Γ Γ' Γ'' : (Γ ≺ Γ') -> (Γ' ≼ Γ'') -> Γ ≺ Γ''.
 Proof. unfold env_order, env_order_refl, ltof. lia. Qed.
 
-Lemma env_order_le_lt_trans Γ Γ' Γ'' : (Γ ≼ Γ') -> (Γ' ≺ Γ'') -> Γ ≺ Γ''.
+Lemma env_order_le_lt_trans {K : Kind} Γ Γ' Γ'' : (Γ ≼ Γ') -> (Γ' ≺ Γ'') -> Γ ≺ Γ''.
 Proof. unfold env_order, env_order_refl, ltof. lia. Qed.
 
-Lemma remove_In_env_order Δ φ:  In φ Δ -> rm φ Δ ≺ Δ.
+Lemma remove_In_env_order {K : Kind} Δ φ:  In φ Δ -> rm φ Δ ≺ Δ.
 Proof.
 intro Hin. apply remove_In_env_order_refl in Hin.
 eapply env_order_lt_le_trans; [|apply Hin]. auto with order.
@@ -340,8 +350,12 @@ Proof. apply elem_of_list_In. Qed.
 
 Global Hint Resolve  elem_of_list_In_1 : order.
 
-Lemma elements_elem_of {Γ : env} {φ : form} : φ ∈ Γ -> elements Γ ≡ₚ φ :: elements (Γ ∖ {[φ]}).
-Proof. intro Hin. rewrite <- elements_env_add. apply Proper_elements, difference_singleton, Hin. Qed.
+Lemma elements_elem_of {K : Kind} {Γ : @env K} {φ : form} :
+  φ ∈ Γ -> elements Γ ≡ₚ φ :: elements (Γ ∖ {[φ]}).
+Proof.
+  intro Hin. setoid_rewrite <- elements_env_add.
+  apply Proper_elements, difference_singleton, Hin.
+Qed.
 
 Ltac prepare_order := 
 repeat (apply env_order_add_compat);
@@ -369,19 +383,19 @@ induction Δ as [|x Δ].
 - simpl. unfold env_order, ltof, env_weight. simpl.
   repeat rewrite <- plus_n_O. apply Nat.add_lt_mono_l.
   rewrite plus_n_O at 1. auto with *.
-- apply (@env_order_equiv_right_compat _  _ (Δ • □ δ • x)). constructor.
+- apply (@env_order_equiv_right_compat _ _  _ (Δ • □ δ • x)). constructor.
   simpl.
-  eapply (@env_order_equiv_left_compat  _ _ (map open_box Δ • δ • δ •  ⊙ x)).
+  eapply (@env_order_equiv_left_compat _ _ _ (map open_box Δ • δ • δ •  ⊙ x)).
   + do 2 (rewrite (Permutation_swap δ (⊙ x)); apply Permutation_skip). trivial.
-  + case x; intros; simpl; try (solve[now apply env_order_add_compat]).
-      transitivity (f :: (□δ) :: Δ).
+  + dependent destruction x; intros; simpl; try (solve[now apply env_order_add_compat]).
+      transitivity (x :: (□δ) :: Δ).
       * auto with *.
       * apply env_order_1. simpl. auto.
 Qed.
 
 Global Hint Resolve openboxes_env_order : order.
 
-Lemma weight_Arrow_1 φ ψ : 1 < weight (φ → ψ).
+Lemma weight_Arrow_1 {K : Kind} φ ψ : 1 < weight (φ → ψ).
 Proof. simpl. pose (weight_pos  φ). lia. Qed.
 
 Lemma weight_Box_1 φ: 1 < weight (□ φ).
@@ -399,7 +413,7 @@ try (apply env_order_disj_union_compat_right; order_tac).
 Global Hint Extern 5 (?a ≺ ?b) => order_tac : proof.
 Hint Extern 5 (?a ≺· ?b) => order_tac : proof.
 
-Lemma pointed_env_order_bot_R pe Δ φ: (pe ≺· (Δ, ⊥)) -> pe ≺· (Δ, φ).
+Lemma pointed_env_order_bot_R {K : Kind} pe Δ φ: (pe ≺· (Δ, ⊥)) -> pe ≺· (Δ, φ).
 Proof.
 intro Hlt. destruct pe as (Γ, ψ). unfold pointed_env_order. simpl.
 eapply env_order_lt_le_trans. exact Hlt. simpl.
@@ -410,7 +424,7 @@ Qed.
 
 Hint Resolve pointed_env_order_bot_R : order.
 
-Lemma pointed_env_order_bot_L pe Δ φ: ((Δ, φ) ≺· pe) -> (Δ, ⊥) ≺· pe.
+Lemma pointed_env_order_bot_L {K : Kind} pe Δ φ: ((Δ, φ) ≺· pe) -> (Δ, ⊥) ≺· pe.
 Proof.
 intro Hlt. destruct pe as (Γ, ψ). unfold pointed_env_order. simpl.
 eapply env_order_le_lt_trans; [|exact Hlt]. simpl.
@@ -421,10 +435,10 @@ Qed.
 
 Hint Resolve pointed_env_order_bot_L : order.
 
-Lemma weight_or_bot a b: weight(⊥) < weight (a ∨b).
+Lemma weight_or_bot {K : Kind} a b: weight(⊥) < weight (a ∨b).
 Proof. destruct a; simpl; lia. Qed.
 
 Hint Resolve weight_or_bot : order.
 
-Definition pointed_env_order_refl pe1 pe2 :=
+Definition pointed_env_order_refl {K : Kind} pe1 pe2 :=
   env_order_refl (pe1.2 :: pe1.2 :: pe1.1) (pe2.2 :: pe2.2 :: pe2.1).

--- a/theories/iSL/Order.v
+++ b/theories/iSL/Order.v
@@ -155,7 +155,6 @@ Proof.
 unfold env_order, ltof. do 2 rewrite env_weight_add. lia.
 Qed.
 
-(* TODO: this is just a special case *)
 Lemma env_order_disj_union_compat_left {K : Kind} Δ Δ' Δ'':
   (Δ ≺ Δ'') -> Δ ++ Δ' ≺ Δ'' ++ Δ'.
 Proof.
@@ -345,7 +344,7 @@ Qed.
 
 Global Hint Resolve remove_In_env_order : order.
 
-Lemma elem_of_list_In_1 {A : Type}: ∀ (l : list A) (x : A), x ∈ l -> In x l.
+Lemma elem_of_list_In_1 {A : Type}: ∀ (l : list A) (x : A), x ∈ l <-> In x l.
 Proof. apply elem_of_list_In. Qed.
 
 Global Hint Resolve  elem_of_list_In_1 : order.

--- a/theories/iSL/PropQuantifiers.v
+++ b/theories/iSL/PropQuantifiers.v
@@ -36,7 +36,6 @@ Variable p : variable.
 (* solves the obligations of the following programs *)
 Obligation Tactic := intros; repeat rewrite <- Eqdep.EqdepTheory.eq_rect_eq in * ; order_tac.
 
-(* TODO: move ? *)
 Notation "□⁻¹ Γ" := (map open_box Γ) (at level 75).
 
 Open Scope list_scope.
@@ -113,8 +112,8 @@ Equations a_rule_env {K : Kind} {Δ : list form} {ϕ : form}
   A ((Δ'•(δ₁ → δ₃))•(δ₂ → δ₃), ϕ) _;
 (* A8 modified*)
 | (δ₁→ δ₂)→ δ₃ := let Δ' := rm ((δ₁→ δ₂)→ δ₃) Δ in
-  (E (Δ'•(δ₂ → δ₃) • δ₁, ϕ) _ ⇢ A (Δ'•(δ₂ → δ₃) • δ₁, δ₂) _) (* TODO: factorize *)
-  ⊼ A (Δ'•δ₃, ϕ) _;
+  (E (Δ'•(δ₂ → δ₃) • δ₁, ϕ) _ ⇢ A (Δ'•(δ₂ → δ₃) • δ₁, δ₂) _)
+  ⊼ A (Δ'• δ₃, ϕ) _;
 | Bot := ⊥;
 | Bot → _ := ⊥;
 | □δ := ⊥;
@@ -143,7 +142,6 @@ Equations a_rule_form {K : Kind} {Δ : list form} (ϕ : form)
 | □δ := □((E ((□⁻¹ Δ) • □δ, ⊥) _) ⇢ A((□⁻¹ Δ) • □δ, δ) _)
 .
 
-(* TODO: move to Order *)
 Instance WF_pointed_env_order {K : Kind} : WellFounded pointed_env_order := wf_pointed_order.
 
 Context {K : Kind}.
@@ -168,7 +166,6 @@ EA false pe :=
 Definition E Δ:= EA true (Δ, ⊥).
 Definition A := EA false.
 
-(* TODO: simplify the output too now rather than in extraction *)
 Definition Ef (ψ : form) := simp_form (E ([simp_form ψ])).
 Definition Af (ψ : form) := simp_form (A ([], simp_form ψ)).
 
@@ -818,9 +815,7 @@ end; simpl.
        -- repeat setoid_rewrite gmultiset_disj_union_assoc.
            setoid_rewrite gmultiset_disj_union_comm.
            repeat setoid_rewrite gmultiset_disj_union_assoc.
-           (* TODO: rewrite exch with explicit arguments *)
-           
-             exch 0. apply ImpR_rev.
+           exch 0. apply ImpR_rev.
            peapply' Hp1.
     * Etac. simpl. apply make_impl_sound_L2', ImpLImp.
       -- apply weakening. apply ImpR. foldEA.
@@ -854,7 +849,7 @@ end; simpl.
               (erewrite proper_Provable;  [| |reflexivity]);  [eapply Hp1|].
               rewrite Heq''. rewrite open_boxes_disj_union.
               repeat rewrite  <- ?list_to_set_disj_open_boxes,  <- list_to_set_disj_env_add.
-              rewrite open_boxes_add. simpl. ms. (* TODO way too long *)
+              rewrite open_boxes_add. simpl. ms.
           -- intro HF. apply (Hnin _ Hin0). simpl. tauto.
         * exch 0. apply weakening. exch 0. apply Hind; [order_tac | occ|peapply' Hp2| trivial].
   + assert(Heq'' : (⊗ Γ0) ≡ ((⊗Γ  ∖ {[□ φ1 → φ2]}) ⊎ ⊗ (list_to_set_disj Δ'))). {

--- a/theories/iSL/PropQuantifiers.v
+++ b/theories/iSL/PropQuantifiers.v
@@ -5,9 +5,9 @@ The main theorem proved in this file was first proved as Theorem 1 in:
 (Pitts 1992). A. M. Pitts. On an interpretation of second order quantification in first order intuitionistic propositional logic. J. Symb. Log., 57(1):33–52.
 It has been further extended to handle iSL
 
-It consists of two parts: 
+It consists of two parts:
 
-1) the inductive construction of the propositional quantifiers; 
+1) the inductive construction of the propositional quantifiers;
 
 2) a proof of its correctness. *)
 
@@ -236,7 +236,7 @@ Proof.
 Qed.
 
 Lemma EA_cong {K : Kind} p Δ ϕ: EA p true (Δ, ϕ) = EA p true (Δ, ⊥).
-Proof. simp EA; simpl. f_equal. apply in_map_ext, e_rule_cong. Qed. 
+Proof. simp EA; simpl. f_equal. apply in_map_ext, e_rule_cong. Qed.
 
 End PropQuant.
 
@@ -291,11 +291,11 @@ Lemma e_rule_vars {K : Kind} Δ (θ : form) (Hin : θ ∈ Δ) (ϕ : form)
   (E0 : ∀ pe (Hpe : pe ≺· (Δ, ϕ)), form)
   (A0 : ∀ pe (Hpe : pe ≺· (Δ, ϕ)), form)
    x
-  (HE0 : ∀ pe Hpe, 
+  (HE0 : ∀ pe Hpe,
       (occurs_in x (E0 pe Hpe) -> x ≠ p ∧ ∃ θ, θ ∈ pe.1 /\ occurs_in x θ) /\
       (occurs_in x (A0 pe Hpe) -> x ≠ p ∧ (occurs_in x pe.2 \/ ∃ θ, θ ∈ pe.1 /\ occurs_in x θ))) :
 occurs_in x (@e_rule p K _ _ E0 A0 θ Hin) -> x ≠ p ∧ ∃ θ, θ ∈ Δ /\ occurs_in x θ.
-Proof. 
+Proof.
 destruct θ; simp e_rule; simpl; try tauto; try solve [repeat case decide; repeat vars_tac].
 destruct θ1; simp e_rule; repeat case decide; repeat vars_tac.
 Qed.
@@ -307,7 +307,7 @@ Lemma a_rule_env_vars {K : Kind} Δ θ Hin ϕ
   (E0 : ∀ pe (Hpe : pe ≺· (Δ, ϕ)), form)
   (A0 : ∀ pe (Hpe : pe ≺· (Δ, ϕ)), form)
    x
-  (HEA0 : ∀ pe Hpe, 
+  (HEA0 : ∀ pe Hpe,
       (occurs_in x (E0 pe Hpe) -> x ≠ p ∧ ∃ θ, θ ∈ pe.1 /\ occurs_in x θ) /\
       (occurs_in x (A0 pe Hpe) -> x ≠ p ∧ (occurs_in x pe.2 \/ ∃ θ, θ ∈ pe.1 /\ occurs_in x θ))):
 occurs_in x (@a_rule_env p K _ _ E0 A0 θ Hin) -> x ≠ p ∧ (occurs_in x ϕ \/ ∃ θ, θ ∈ Δ /\ occurs_in x θ).
@@ -321,11 +321,11 @@ Lemma a_rule_form_vars {K : Kind} Δ ϕ
   (E0 : ∀ pe (Hpe : pe ≺· (Δ, ϕ)), form)
   (A0 : ∀ pe (Hpe : pe ≺· (Δ, ϕ)), form)
    x
-  (HEA0 : ∀ pe Hpe, 
+  (HEA0 : ∀ pe Hpe,
       (occurs_in x (E0 pe Hpe) -> x ≠ p ∧ ∃ θ, θ ∈ pe.1 /\ occurs_in x θ) /\
       (occurs_in x (A0 pe Hpe) -> x ≠ p ∧ (occurs_in x pe.2 \/ ∃ θ, θ ∈ pe.1 /\ occurs_in x θ))):
   occurs_in x (@a_rule_form p K _ _ E0 A0) -> x ≠ p ∧ (occurs_in x ϕ \/ ∃ θ, θ ∈ Δ /\ occurs_in x θ).
-Proof. 
+Proof.
 destruct ϕ; simp a_rule_form; simpl; try tauto; try solve [repeat case decide; repeat vars_tac].
 Qed.
 
@@ -540,14 +540,14 @@ Lemma E_simp_env {K : Kind} Δ : E p (simp_env Δ) = E p Δ.
 (* unfold E, A. simp EA; simpl. *)
 Proof. unfold E; simp EA. simpl. now rewrite simp_env_idempotent. Qed.
 
-Lemma E_left {K : Kind} {Γ θ} {Δ' Δ : list form} {φ : form}: (Δ' = simp_env Δ) -> ∀ (Hin : φ ∈ Δ'), 
+Lemma E_left {K : Kind} {Γ θ} {Δ' Δ : list form} {φ : form}: (Δ' = simp_env Δ) -> ∀ (Hin : φ ∈ Δ'),
 (Γ • @e_rule p _ _ _ (λ pe (_ : pe ≺· (Δ', ⊥)),  E p pe.1) (λ pe (_ : pe ≺· (Δ', ⊥)),  A p pe)  φ Hin) ⊢ θ ->
 Γ • E p Δ' ⊢ θ.
 Proof.
 intros Heq Hin Hp.
 unfold E. erewrite <- EA_cong . simp EA. simpl. subst Δ'.
 rewrite simp_env_idempotent.
-match goal with |- context C [in_map ?Γ ?f] => 
+match goal with |- context C [in_map ?Γ ?f] =>
   edestruct (@in_map_in _ _ form_eq_dec _ f _ Hin) as [Hin' Hrule]
 end.
 eapply conjunction_L.
@@ -558,7 +558,7 @@ eapply conjunction_L.
   + trivial.
 Qed.
 
-Local Lemma A_right {K : Kind} {Γ Δ Δ' φ φ'} : (Δ' = simp_env Δ) -> ∀ (Hin : φ ∈ Δ'), 
+Local Lemma A_right {K : Kind} {Γ Δ Δ' φ φ'} : (Δ' = simp_env Δ) -> ∀ (Hin : φ ∈ Δ'),
 Γ ⊢ @a_rule_env p _ _ _ (λ pe (_ : pe ≺· (Δ', φ')), E p pe.1) (λ pe (_ : pe ≺· (Δ', φ')), A p pe) φ Hin ->
 Γ ⊢ A p (Δ', φ').
 Proof.  intros Heq Hin Hp. subst Δ'. rewrite A_simp_env. unfold A; simp EA; simpl.
@@ -588,7 +588,7 @@ Local Ltac Etac := foldEA; intros; match goal with
 
 (* we want to use an A rule defined in a_rule_env *)
 Local Ltac Atac := match goal with
-| HeqΔ': ?Δ' = simp_env ?Δ, Hin : ?a ∈ list_to_set_disj ?Δ'  |- _  ⊢ A _ (?Δ', _) => 
+| HeqΔ': ?Δ' = simp_env ?Δ, Hin : ?a ∈ list_to_set_disj ?Δ'  |- _  ⊢ A _ (?Δ', _) =>
   apply (A_right HeqΔ' (proj1 (elem_of_list_to_set_disj _ _) Hin)); simp a_rule_env end.
 
 (* we want to use an A rule defined in a_rule_form *)
@@ -717,7 +717,7 @@ end; simpl.
     case (decide (Var p0 ∈ Γ)); intro Hin1.
     * (* subcase 1: p0, (p0 → φ) ∈ Γ *)
       assert (Hin2 : Var p0 ∈ Γ ∖ {[Var p0 → φ]}) by (apply in_difference; trivial; discriminate).
-      clear Hin1. 
+      clear Hin1.
       split; [intro Hocc|]; exhibit Hin0 1; exhibit Hin2 2; exch 0; exch 1; apply ImpLVar; exch 1; exch 0;
       (apply Hind; auto with proof; [occ | peapply' Hp]).
     * assert(Hin0' : Var p0 ∈ (Γ0•Var p0•(p0 → φ))) by ms. rewrite Heq in Hin0'.
@@ -768,7 +768,7 @@ end; simpl.
                  assert((p0 → φ) ∈ list_to_set_disj Δ') by ms. Etac.
                  rewrite decide_True by now apply elem_of_list_to_set_disj.
                  exch 0. apply weakening. apply Hind; auto with proof. simpl. peapply' Hp.
-         ++ apply contraction. Etac. exch 0. assert((p0 → φ) ∈ list_to_set_disj Δ') by ms. 
+         ++ apply contraction. Etac. exch 0. assert((p0 → φ) ∈ list_to_set_disj Δ') by ms.
                  Etac; Atac. rewrite decide_False by trivial.
                  do 2 rewrite decide_True by now apply elem_of_list_to_set_disj.
                  exch 0. apply weakening.
@@ -890,7 +890,7 @@ end; simpl.
               rewrite open_boxes_add. simpl. ms.
          -- intro HF. apply (Hnin _ Hin0). simpl. tauto.
         * exch 0. apply weakening. exch 0. apply Hind ; [order_tac|occ|peapply' Hp2].
-  + exch 0. apply ImpBox. 
+  + exch 0. apply ImpBox.
       * box_tac. exch 1; exch 0. apply open_box_L. apply Hind.
          --  order_tac. rewrite  elements_open_boxes.  order_tac.
          -- occ. intro HF. destruct (occurs_in_open_boxes _ _ _ HF Hin1) as (θ0 & Hθ0 & Hinθ).
@@ -905,7 +905,7 @@ end; simpl.
 - split; Etac.
   + foldEA. apply make_impl_sound_L, ImpBox.
         -- do 2 apply weakening. apply make_impl_sound_R, ImpR, Hind.
-             ++ order_tac. rewrite elements_open_boxes. 
+             ++ order_tac. rewrite elements_open_boxes.
                      do 2 apply env_order_cancel_right.
                      repeat rewrite Permutation_middle.
                      apply env_order_disj_union_compat_strong_left; order_tac.
@@ -937,9 +937,9 @@ end; simpl.
             ++ intros φ0 Hin1 HF. destruct (occurs_in_open_boxes _ _ _ HF Hin1) as (θ0 & Hθ0 & Hinθ).
                     apply (Hnin θ0); ms.
             ++ peapply Hp1.
-       -- apply BoxR. box_tac. do 2 apply weakening. apply make_impl_sound_R, ImpR. foldEA. 
+       -- apply BoxR. box_tac. do 2 apply weakening. apply make_impl_sound_R, ImpR. foldEA.
            apply Hind.
-             ++ order_tac. rewrite elements_open_boxes. 
+             ++ order_tac. rewrite elements_open_boxes.
                      do 2 apply env_order_cancel_right.
                      repeat rewrite Permutation_middle.
                      apply env_order_disj_union_compat_strong_left; order_tac.
@@ -948,7 +948,7 @@ end; simpl.
             ++ peapply Hp1.
      * foldEA. apply make_impl_sound_L, ImpBox.
         -- do 2 apply weakening. apply make_impl_sound_R, ImpR, Hind.
-             ++ order_tac. rewrite elements_open_boxes. 
+             ++ order_tac. rewrite elements_open_boxes.
                      do 2 apply env_order_cancel_right.
                      repeat rewrite Permutation_middle.
                      apply env_order_disj_union_compat_strong_left; order_tac.

--- a/theories/iSL/SequentProps.v
+++ b/theories/iSL/SequentProps.v
@@ -18,9 +18,15 @@ Logic (65):4.
 
 (** ** Weakening *)
 
+Lemma open_boxes_add'
+     {K : Kind} (Γ : @env K) (φ : @form K) : (⊗ (Γ • φ)) = (⊗ Γ • ⊙ φ).
+Proof. apply open_boxes_add. Qed.
+(*
+Global Hint Rewrite open_boxes_add' : proof.
+*)
 (** We prove the admissibility of the weakening rule. *)
 
-Theorem weakening φ' Γ φ : Γ ⊢ φ -> Γ•φ' ⊢ φ.
+Theorem weakening {K : Kind} φ' Γ φ : Γ ⊢ φ -> Γ•φ' ⊢ φ.
 Proof with (auto with proof).
 intro H. revert φ'.  induction H; intro φ'; auto with proof; try (exch 0; auto with proof).
 - constructor 4. exch 1; exch 0...
@@ -33,12 +39,12 @@ intro H. revert φ'.  induction H; intro φ'; auto with proof; try (exch 0; auto
 - apply ImpBox; box_tac.
   + peapply (IHProvable1 (open_box φ')).
   + exch 0...
-- apply BoxR. box_tac; exch 0...
+- apply BoxR. box_tac. exch 0...
 Qed.
 
 Global Hint Resolve weakening : proof.
 
-Theorem generalised_weakeningL (Γ Γ' : env) φ: Γ ⊢ φ -> Γ' ⊎ Γ ⊢ φ.
+Theorem generalised_weakeningL {K : Kind} (Γ Γ' : env) φ: Γ ⊢ φ -> Γ' ⊎ Γ ⊢ φ.
 Proof.
 intro Hp.
 induction Γ' as [| x Γ' IHΓ'] using gmultiset_rec.
@@ -46,7 +52,7 @@ induction Γ' as [| x Γ' IHΓ'] using gmultiset_rec.
 - peapply (weakening x). exact IHΓ'. ms.
 Qed.
 
-Theorem generalised_weakeningR (Γ Γ' : env) φ: Γ' ⊢ φ -> Γ' ⊎ Γ ⊢ φ.
+Theorem generalised_weakeningR {K : Kind} (Γ Γ' : env) φ: Γ' ⊢ φ -> Γ' ⊎ Γ ⊢ φ.
 Proof.
 intro Hp.
 induction Γ as [| x Γ IHΓ] using gmultiset_rec.
@@ -62,7 +68,7 @@ Global Hint Extern 5 (?a <= ?b) => simpl in *; lia : proof.
   left, or left, top left (i.e., the appliction of weakening for the formula
   top), the four implication left rules, the and right rule and the application of the or right rule with bottom. *)
 
-Lemma ImpR_rev Γ φ ψ :
+Lemma ImpR_rev {K : Kind} Γ φ ψ :
   (Γ ⊢ (φ →  ψ))
     -> Γ•φ ⊢  ψ.
 Proof with (auto with proof).
@@ -74,13 +80,13 @@ intro Hp. dependent induction Hp; auto with proof; try exch 0.
 - constructor 11. exch 1; exch 0...
 - constructor 12; exch 0...
 - constructor 13; box_tac...
-  + exch 1; exch 0...
+  + exch 1; exch 0. apply weakening...
   + exch 0. auto with proof.
 Qed.
 
 Global Hint Resolve ImpR_rev : proof.
 
-Theorem generalised_axiom Γ φ : Γ•φ ⊢ φ.
+Theorem generalised_axiom {K : Kind} Γ φ : Γ • φ ⊢ φ.
 Proof with (auto with proof).
 remember (weight φ) as w.
 assert(Hle : weight φ ≤ w) by lia.
@@ -88,7 +94,7 @@ clear Heqw. revert Γ φ Hle.
 induction w; intros Γ φ Hle.
 - assert (Hφ := weight_pos φ). lia.
 - destruct φ; simpl in Hle...
-  destruct φ1 as [v| | θ1 θ2 | θ1 θ2 | θ1 θ2 | θ].
+  dependent destruction φ1.
   + constructor 8. exch 0...
   + auto with proof.
   + apply ImpR, AndL. exch 1; exch 0. apply ImpLAnd.
@@ -105,7 +111,7 @@ Global Hint Resolve generalised_axiom : proof.
 Local Ltac lazy_apply th:=
 (erewrite proper_Provable;  [| |reflexivity]);  [eapply th|].
 
-Lemma open_box_L Γ φ ψ : Γ • φ ⊢ ψ -> Γ • ⊙ φ ⊢ ψ.
+Lemma open_box_L {K : Kind} Γ φ ψ : Γ • φ ⊢ ψ -> Γ • ⊙ φ ⊢ ψ.
 Proof.
 intro Hp.
 remember (Γ•φ) as Γ' eqn:HH.
@@ -122,7 +128,8 @@ dependent induction Hp generalizing Γ' Hp; intros φ0 Hin.
 - apply AndR; auto.
 - case (decide (φ0 = (φ ∧ ψ))).
   + intro; subst. simpl. apply AndL. peapply Hp.
-  + intro. forward. apply AndL. do 2 backward. peapply (IHHp φ0). ms.
+  + intro. forward. apply AndL. exch 0. do 2 backward.
+    peapply (IHHp); trivial. ms.
 - apply OrR1; auto.
 - apply OrR2; auto.
 - case (decide (φ0 = (φ ∨ ψ))).
@@ -130,71 +137,71 @@ dependent induction Hp generalizing Γ' Hp; intros φ0 Hin.
       * peapply Hp1.
       * peapply Hp2.
   + intro. forward. apply OrL.
-      * backward. peapply (IHHp1 φ0). ms.
-      * backward. peapply (IHHp2 φ0). ms.
-- apply ImpR. backward. apply IHHp. ms.
+      * backward. peapply IHHp1; trivial. ms.
+      * backward. peapply IHHp2; trivial. ms.
+- apply ImpR. backward. apply IHHp; trivial. ms.
 - case (decide (φ0 = Var p)).
   + intro; subst; simpl. forward. apply ImpLVar. peapply Hp.
   + intro. case (decide (φ0 = (Var p → φ))).
-      * intro; subst; simpl. peapply ImpLVar. exact Hp. ms.
+      * intro; subst; simpl. peapply (ImpLVar Γ). exact Hp. ms.
       * intro. do 2 forward. exch 0. apply ImpLVar. exch 0. do 2 backward.
-         apply IHHp. ms.
+         apply IHHp; trivial. ms.
 - case (decide (φ0 =  (φ1 ∧ φ2 → φ3))).
   + intro; subst; simpl. apply ImpLAnd. peapply Hp. 
-  + intro. forward. apply ImpLAnd. backward. apply IHHp. ms.
+  + intro. forward. apply ImpLAnd. backward. apply IHHp; trivial. ms.
 - case (decide (φ0 =  (φ1 ∨ φ2 → φ3))).
   + intro; subst; simpl. apply ImpLOr. peapply Hp.
-  + intro. forward. apply ImpLOr. exch  0. do 2 backward. apply IHHp. ms.
+  + intro. forward. apply ImpLOr. exch  0. do 2 backward. apply IHHp; trivial. ms.
 - case (decide (φ0 =  ((φ1 → φ2) → φ3))).
   + intro; subst; simpl. apply ImpLImp. peapply Hp1. peapply Hp2.
   + intro. forward. apply ImpLImp.
-      * backward. apply IHHp1. ms.
-      * backward. apply IHHp2. ms.
+      * backward. apply IHHp1; trivial. ms.
+      * backward. apply IHHp2; trivial. ms.
 - case (decide (φ0 =  (□ φ1 → φ2))).
   + intro; subst; simpl. apply ImpBox.
-      * lazy_apply Hp1; autorewrite with proof; ms.
+      * box_tac. lazy_apply Hp1. autorewrite with proof. ms.
       * peapply Hp2.
   + intro. forward.
       case (decide (open_box φ0 = □ φ1)).
       * intro Heq. repeat rewrite Heq. apply ImpBox; box_tac.
         -- exch 1; exch 0. apply generalised_axiom.
-        -- backward. rewrite <- Heq. apply IHHp2. auto with *.
+        -- backward. rewrite <- Heq. apply IHHp2; trivial. auto with *.
       * intro Hneq. case (decide (open_box φ0 = φ2)).
           -- intro Heq. subst φ2. apply ImpBox; box_tac.
-              ++ (erewrite proper_Provable;  [| |reflexivity]);  [eapply (IHHp1 (⊙ φ0))|].
-                      ms.
-                      autorewrite with proof; [|ms]. repeat rewrite env_replace.
+              ++ (erewrite proper_Provable;  [| |reflexivity]);  [eapply (IHHp1 (⊙ φ0))|]. ms.
+                 autorewrite with proof; [|ms]. repeat rewrite env_replace.
                      ** ms.
                      ** auto with proof.
                      ** apply env_in_add. right. auto with proof; ms.
-              ++ box_tac. backward. apply (IHHp2 φ0). auto with *.
+              ++ box_tac. backward. apply IHHp2; trivial. auto with *.
           -- intro Hneq'. apply ImpBox; repeat box_tac.
             ++ exch 0. box_tac. assert((⊙ φ0) ∈ (⊗ Γ)) by (now apply In_open_boxes).
-                    backward. backward. eapply (IHHp1 (⊙ φ0)). ms.
-            ++ backward. apply IHHp2.  apply env_in_add. now right.
+                    backward. backward. eapply IHHp1; trivial. ms.
+            ++ backward. apply IHHp2; trivial. apply env_in_add. now right.
 - case (decide (open_box φ0 = □ φ)).
   + intro Heq; rewrite Heq. apply generalised_axiom.
   + intro. backward. apply BoxR. box_tac.
       case (decide (open_box φ0 = open_box (open_box φ0))).
       * intro Heq. lazy_apply Hp. autorewrite with proof. rewrite <- Heq. ms. ms.
       * intro. assert( open_box φ0 ∈ open_boxes Γ) by (now apply In_open_boxes).
-         lazy_apply (IHHp (open_box φ0)).
+        lazy_apply (IHHp (open_box φ0)).
         -- ms.
         -- autorewrite with proof. repeat rewrite env_replace; ms. ms.
 Qed.
 
 Local Hint Resolve env_in_add : proof.
 
-Lemma open_boxes_R (Γ : env) (φ ψ : form): (Γ • φ) ⊢ ψ → ((⊗Γ) • φ) ⊢ ψ.
+Lemma open_boxes_R {K : Kind} (Γ : env) φ ψ: (Γ • φ) ⊢ ψ → (⊗Γ) • φ ⊢ ψ.
 Proof.
 revert ψ.
 induction Γ using gmultiset_rec; intro ψ.
 - rewrite open_boxes_empty. trivial.
-- intro HP. lazy_apply (open_box_L  (⊗ Γ • φ) x ψ).
+- intro HP. lazy_apply (open_box_L (⊗ Γ • φ) x ψ).
   + apply ImpR_rev, IHΓ, ImpR. peapply HP.
   + rewrite open_boxes_disj_union, open_boxes_singleton; ms.
 Qed.
-Lemma AndL_rev Γ φ ψ θ: (Γ•φ ∧ ψ) ⊢ θ  → (Γ•φ•ψ) ⊢ θ.
+
+Lemma AndL_rev {K : Kind} Γ φ ψ θ: (Γ•φ ∧ ψ) ⊢ θ  → (Γ•φ•ψ) ⊢ θ.
 Proof.
 intro Hp.
 remember (Γ•φ ∧ ψ) as Γ' eqn:HH.
@@ -203,30 +210,31 @@ assert(Hin : (φ ∧ ψ) ∈ Γ')by ms.
 rw Heq 2. clear Γ HH Heq. revert φ ψ Hin.
 (* we massaged the goal so that the environment of the derivation on which we do
    the induction is not composite anymore *)
-induction Hp; intros φ0 ψ0 Hin; try forward.
+induction Hp; intros φ0 ψ0 Hin.
 (* auto takes care of the right rules easily *)
-- auto with proof.
-- auto with proof.
+- forward. auto with proof.
+- forward. auto with proof.
 - apply AndR; auto with proof.
 (* the main case *)
-- case(decide ((φ ∧ ψ) = (φ0 ∧ ψ0))); intro Heq0.
-  + inversion Heq0; subst. peapply Hp.
+- (* TODO: forward gets stuck there. *)
+  case(decide ((φ ∧ ψ) = (φ0 ∧ ψ0))); intro Heq0.
+  + dependent destruction Heq0; subst. peapply Hp.
   + forward. constructor 4. exch 0. backward. backward. apply IHHp. ms.
 (* only left rules remain. Now it's all a matter of putting the right principal
    formula at the front, apply the rule; and put back the front formula at the back
    before applying the induction hypothesis *)
 - apply OrR1. auto with proof.
 - apply OrR2. auto with proof.
-- constructor 7; backward; [apply IHHp1 | apply IHHp2]; ms.
+- forward. constructor 7; backward; [apply IHHp1 | apply IHHp2]; ms.
 - constructor 8. backward. apply IHHp. ms.
-- forward. exch 0. constructor 9. exch 0. do 2 backward. apply IHHp. ms.
-- constructor 10. backward. apply IHHp. ms.
-- constructor 11. exch 0. do 2 backward. apply IHHp. ms.
-- constructor 12; backward.
+- forward. forward. exch 0. constructor 9. exch 0. do 2 backward. apply IHHp. ms.
+- forward. constructor 10. backward. apply IHHp. ms.
+- forward. constructor 11. exch 0. do 2 backward. apply IHHp. ms.
+- forward. constructor 12; backward.
   + apply IHHp1. ms.
   + apply IHHp2. ms.
-- constructor 13; repeat box_tac.
-  + exch 0.  box_tac.
+- forward. constructor 13; repeat box_tac.
+  + exch 0. box_tac.
       apply In_open_boxes in Hin0. backward. backward. apply open_box_L. exch 0. apply open_box_L. exch 0. 
       apply IHHp1. ms.
   + backward. apply IHHp2. ms.
@@ -239,7 +247,7 @@ induction Hp; intros φ0 ψ0 Hin; try forward.
       apply In_open_boxes in Hin. auto with proof.
 Qed.
 
-Lemma OrL_rev Γ φ ψ θ: (Γ•φ ∨ ψ) ⊢ θ  → (Γ•φ ⊢ θ)  * (Γ•ψ ⊢ θ).
+Lemma OrL_rev {K : Kind} Γ φ ψ θ: (Γ•φ ∨ ψ) ⊢ θ  → (Γ•φ ⊢ θ) * (Γ•ψ ⊢ θ).
 Proof.
 intro Hp.
 remember (Γ•φ ∨ ψ) as Γ' eqn:HH.
@@ -251,12 +259,12 @@ clear Γ HH Heq.
 induction Hp.
 - split; forward; auto with proof.
 - split; forward; auto with proof.
-- split; constructor 3; intuition.
+- split; constructor 3; now (apply IHHp1 || apply IHHp2).
 - split; forward; constructor 4; exch 0; do 2 backward; apply IHHp; ms.
-- split; constructor 5; intuition.
-- split; apply OrR2; intuition.
+- split; constructor 5; now apply IHHp.
+- split; apply OrR2; now apply IHHp.
 - case (decide ((φ0 ∨ ψ0) = (φ ∨ ψ))); intro Heq0.
-  + inversion Heq0; subst. split; [peapply Hp1| peapply Hp2].
+  + dependent destruction Heq0; subst. split; [peapply Hp1| peapply Hp2].
   + split; forward; constructor 7; backward; (apply IHHp1||apply IHHp2); ms.
 - split; constructor 8; backward; apply IHHp; ms.
 - split; do 2 forward; exch 0; constructor 9; exch 0; do 2 backward; apply IHHp; ms.
@@ -264,15 +272,20 @@ induction Hp.
 - split; forward; constructor 11; exch 0; do 2 backward; apply IHHp; ms.
 - split; forward; constructor 12; backward; (apply IHHp1 || apply IHHp2); ms.
 - split; forward; assert(Hin' : (φ ∨ ψ) ∈ (⊗ Γ • □ φ1 • φ2))
-  by (apply env_in_add; right; apply env_in_add; right; auto with proof);
-  assert((φ ∨ ψ) ∈ ⊗Γ) by auto with proof;
+  by (apply env_in_add; right; apply env_in_add; right; eauto with proof);
+  assert((φ ∨ ψ) ∈ ⊗Γ) by eauto with proof;
   (constructor 13; repeat box_tac; exch 0;
     [do 2 backward; apply open_box_L; apply IHHp1|exch 0; backward; apply IHHp2];ms).
--  assert (Hin' : (φ ∨ ψ) ∈ (⊗ Γ • □ φ0)) by (apply env_in_add; right; auto with proof).
+-  assert (Hin' : (φ ∨ ψ) ∈ (⊗ Γ • □ φ0)) by (apply env_in_add; right; eauto with proof).
     split; constructor 14; repeat box_tac; backward; apply open_box_L; now apply IHHp.
 Qed.
+(*
+Lemma open_boxes_spec Γ φ : φ ∈ open_boxes Γ -> {φ ∈ Γ ∧ is_box φ = false} + {(□ φ) ∈ Γ}.
+Admitted.
+  Global Hint Resolve open_boxes_spec : proof.
 
-Lemma TopL_rev Γ φ θ: Γ•(⊥ → φ) ⊢ θ -> Γ ⊢ θ.
+*)
+Lemma TopL_rev {K : Kind} Γ φ θ: Γ•(⊥ → φ) ⊢ θ -> Γ ⊢ θ.
 Proof.
 remember (Γ•(⊥ → φ)) as Γ' eqn:HH.
 assert (Heq: Γ ≡ Γ' ∖ {[ ⊥ → φ ]}) by ms.
@@ -299,58 +312,58 @@ Qed.
 
 Local Hint Immediate TopL_rev : proof.
 
-Lemma ImpLVar_rev Γ p φ ψ: (Γ•Var p•(p → φ)) ⊢ ψ  → (Γ•Var p•φ) ⊢ ψ.
+Lemma ImpLVar_rev {K : Kind} Γ p φ ψ: (Γ•Var p•(p → φ)) ⊢ ψ  → (Γ•Var p•φ) ⊢ ψ.
 Proof.
 intro Hp.
 remember (Γ•Var p•(p → φ)) as Γ' eqn:HH.
 assert (Heq: (Γ•Var p) ≡ Γ' ∖ {[Var p → φ]}) by ms.
 assert(Hin : (p → φ) ∈ Γ')by ms.
 rw Heq 1. clear Γ HH Heq.
-induction Hp; try forward.
-- auto with proof.
-- auto with proof.
+induction Hp.
+- forward; auto with proof.
+- forward; auto with proof.
 - apply AndR; auto with proof.
-- apply AndL. exch 0. do 2 backward. apply IHHp. ms.
+- forward; apply AndL. exch 0. do 2 backward. apply IHHp. ms.
 - apply OrR1. auto with proof.
 - apply OrR2. auto with proof.
-- apply OrL; backward; apply IHHp1 || apply IHHp2; ms.
+- forward; apply OrL; backward; apply IHHp1 || apply IHHp2; ms.
 - apply ImpR. backward. apply IHHp. ms.
 - case (decide ((Var p0 → φ0) = (Var p → φ))); intro Heq0.
-  + inversion Heq0; subst. peapply Hp.
+  + dependent destruction Heq0; subst. peapply Hp.
   + do 2 forward. exch 0. apply ImpLVar. exch 0; do 2 backward. apply IHHp. ms.
-- apply ImpLAnd. backward. apply IHHp. ms.
-- apply ImpLOr. exch 0; do 2 backward. apply IHHp. ms.
-- apply ImpLImp; backward; (apply IHHp1 || apply IHHp2); ms.
--  apply ImpBox; repeat box_tac.
+- forward; apply ImpLAnd. backward. apply IHHp. ms.
+- forward; apply ImpLOr. exch 0; do 2 backward. apply IHHp. ms.
+- forward; apply ImpLImp; backward; (apply IHHp1 || apply IHHp2); ms.
+- forward; apply ImpBox; repeat box_tac.
    +  exch 0; do 2 backward. apply open_box_L. apply IHHp1. ms.
-   + backward.  apply IHHp2. ms.
-- apply BoxR.  repeat box_tac. backward. apply open_box_L. apply IHHp. ms.
+   + backward. apply IHHp2. ms.
+- apply BoxR. repeat box_tac. backward. apply open_box_L. apply IHHp. ms.
 Qed.
 
 (* inversion for ImpLImp is only partial *)
-Lemma ImpLImp_prev Γ φ1 φ2 φ3 ψ: (Γ•((φ1 → φ2) → φ3)) ⊢ ψ -> (Γ•φ3) ⊢ ψ.
+Lemma ImpLImp_prev {K : Kind} Γ φ1 φ2 φ3 ψ: (Γ•((φ1 → φ2) → φ3)) ⊢ ψ -> (Γ•φ3) ⊢ ψ.
 Proof.
 intro Hp.
 remember (Γ •((φ1 → φ2) → φ3)) as Γ' eqn:HH.
 assert (Heq: Γ ≡ Γ' ∖ {[ ((φ1 → φ2) → φ3) ]}) by ms.
 assert(Hin :((φ1 → φ2) → φ3) ∈ Γ')by ms.
 rw Heq 1. clear Γ HH Heq.
-induction Hp; try forward.
-- auto with proof.
-- auto with proof.
+induction Hp.
+- forward; auto with proof.
+- forward; auto with proof.
 - apply AndR; auto with proof.
-- apply AndL. exch 0; do 2 backward. apply IHHp. ms.
+- forward; apply AndL. exch 0; do 2 backward. apply IHHp. ms.
 - apply OrR1. auto with proof.
 - apply OrR2. auto with proof.
--  apply OrL; backward; [apply IHHp1 | apply IHHp2]; ms.
+- forward; apply OrL; backward; [apply IHHp1 | apply IHHp2]; ms.
 - apply ImpR. backward. apply IHHp. ms.
-- forward. exch 0. apply ImpLVar. exch 0. do 2 backward. apply IHHp. ms.
-- apply ImpLAnd. backward. apply IHHp. ms.
-- apply ImpLOr. exch 0. do 2 backward. apply IHHp. ms.
+- do 2 forward. exch 0. apply ImpLVar. exch 0. do 2 backward. apply IHHp. ms.
+- forward; apply ImpLAnd. backward. apply IHHp. ms.
+- forward; apply ImpLOr. exch 0. do 2 backward. apply IHHp. ms.
 - case (decide (((φ0 → φ4) → φ5) = ((φ1 → φ2) → φ3))); intro Heq0.
-  + inversion Heq0; subst. peapply Hp2.
+  + dependent destruction Heq0; subst. peapply Hp2.
   + forward. apply ImpLImp; backward; (apply IHHp1 || apply IHHp2); ms.
--  apply ImpBox; repeat box_tac.
+- forward; apply ImpBox; repeat box_tac.
   + exch 0; do 2 backward. apply open_box_L. apply IHHp1. ms.
   + backward. apply IHHp2. ms.
 - apply BoxR. repeat box_tac. backward. apply open_box_L. apply IHHp. ms.
@@ -364,79 +377,82 @@ remember (Γ •((□φ1) → φ2)) as Γ' eqn:HH.
 assert (Heq: Γ ≡ Γ' ∖ {[ ((□φ1) → φ2) ]}) by ms.
 assert(Hin :((□φ1) → φ2) ∈ Γ')by ms.
 rw Heq 1. clear Γ HH Heq.
-induction Hp; try forward.
-- auto with proof.
-- auto with proof.
+dependent induction Hp.
+- forward; auto with proof.
+- forward; auto with proof.
 - apply AndR; auto with proof.
-- apply AndL. exch 0; do 2 backward. apply IHHp. ms.
+- forward; apply AndL. exch 0; do 2 backward. apply IHHp; trivial. ms.
 - apply OrR1. auto with proof.
 - apply OrR2. auto with proof.
--  apply OrL; backward; [apply IHHp1 | apply IHHp2]; ms.
-- apply ImpR. backward. apply IHHp. ms.
-- forward. exch 0. apply ImpLVar. exch 0. do 2 backward. apply IHHp. ms.
-- apply ImpLAnd. backward. apply IHHp. ms.
-- apply ImpLOr. exch 0. do 2 backward. apply IHHp. ms.
-- apply ImpLImp; backward; (apply IHHp1 || apply IHHp2); ms.
+- forward; apply OrL; backward; [apply IHHp1 | apply IHHp2]; ms.
+- apply ImpR. backward. apply IHHp; trivial. ms.
+- do 2 forward. exch 0. apply ImpLVar. exch 0. do 2 backward.
+  apply IHHp; trivial. ms.
+- forward; apply ImpLAnd. backward. apply IHHp; trivial. ms.
+- forward; apply ImpLOr. exch 0. do 2 backward. apply IHHp; trivial. ms.
+- forward; apply ImpLImp; backward. 
+  + apply IHHp1; trivial. ms.
+  + apply IHHp2; trivial. ms.
 - case (decide((□φ0 → φ3) = (□φ1 → φ2))).
-  + intro Heq; inversion Heq; subst. peapply Hp2.
+  + intro Heq; dependent destruction Heq; subst. peapply Hp2.
   + intro Hneq. forward. apply ImpBox; repeat box_tac.
-     * exch 0; do 2 backward. apply open_box_L; apply IHHp1. ms.
-     * backward. apply IHHp2. ms.
-- apply BoxR. repeat box_tac. backward. apply open_box_L. apply IHHp. ms.
+     * exch 0; do 2 backward. apply open_box_L; apply IHHp1; trivial. ms.
+     * backward. apply IHHp2; trivial. ms.
+- apply BoxR. repeat box_tac. backward. apply open_box_L. apply IHHp; trivial. ms.
 Qed.
 
-
-Lemma ImpLOr_rev Γ φ1 φ2 φ3 ψ: Γ•((φ1 ∨ φ2) → φ3) ⊢ ψ -> Γ•(φ1 → φ3)•(φ2 → φ3) ⊢ ψ.
+Lemma ImpLOr_rev {K : Kind} Γ φ1 φ2 φ3 ψ:
+  Γ•((φ1 ∨ φ2) → φ3) ⊢ ψ -> Γ•(φ1 → φ3)•(φ2 → φ3) ⊢ ψ.
 Proof.
 intro Hp.
 remember (Γ •((φ1 ∨ φ2) → φ3)) as Γ' eqn:HH.
 assert (Heq: Γ ≡ Γ' ∖ {[ ((φ1 ∨ φ2) → φ3) ]}) by ms.
 assert(Hin :((φ1 ∨ φ2) → φ3) ∈ Γ')by ms.
 rw Heq 2. clear Γ HH Heq.
-induction Hp; try forward.
-- auto with proof.
-- auto with proof.
+induction Hp.
+- forward; auto with proof.
+- forward; auto with proof.
 - apply AndR; auto with proof.
-- constructor 4. exch 0; do 2 backward. apply IHHp. ms.
+- forward; constructor 4. exch 0; do 2 backward. apply IHHp. ms.
 - apply OrR1. auto with proof.
 - apply OrR2. auto with proof.
-- constructor 7; backward; [apply IHHp1 | apply IHHp2]; ms.
+- forward; constructor 7; backward; [apply IHHp1 | apply IHHp2]; ms.
 - constructor 8. backward. apply IHHp. ms.
-- forward. exch 0. constructor 9. exch 0. do 2 backward. apply IHHp. ms.
-- constructor 10. backward. apply IHHp. ms.
+- do 2 forward. exch 0. constructor 9. exch 0. do 2 backward. apply IHHp. ms.
+- forward; constructor 10. backward. apply IHHp. ms.
 - case (decide (((φ0 ∨ φ4) → φ5) = ((φ1 ∨ φ2) → φ3))); intro Heq0.
-  + inversion Heq0; subst. peapply Hp.
+  + dependent destruction Heq0; subst. peapply Hp.
   + forward. constructor 11; exch 0; do 2 backward; apply IHHp; ms.
-- constructor 12; backward; (apply IHHp1 || apply IHHp2); ms.
--  apply ImpBox; repeat box_tac.
+- forward; constructor 12; backward; (apply IHHp1 || apply IHHp2); ms.
+- forward; apply ImpBox; repeat box_tac.
   + exch 0; do 2 backward. apply IHHp1. ms.
   + backward. apply IHHp2. ms.
 - apply BoxR. repeat box_tac. backward. apply IHHp. ms.
 Qed.
 
-Lemma ImpLAnd_rev Γ φ1 φ2 φ3 ψ: (Γ•(φ1 ∧ φ2 → φ3)) ⊢ ψ ->  (Γ•(φ1 → φ2 → φ3)) ⊢ ψ .
+Lemma ImpLAnd_rev {K : Kind} Γ φ1 φ2 φ3 ψ: (Γ•(φ1 ∧ φ2 → φ3)) ⊢ ψ ->  (Γ•(φ1 → φ2 → φ3)) ⊢ ψ .
 Proof.
 intro Hp.
 remember (Γ •((φ1 ∧ φ2) → φ3)) as Γ' eqn:HH.
 assert (Heq: Γ ≡ Γ' ∖ {[ ((φ1 ∧ φ2) → φ3) ]}) by ms.
 assert(Hin :((φ1 ∧ φ2) → φ3) ∈ Γ')by ms.
 rw Heq 1. clear Γ HH Heq.
-induction Hp; try forward.
-- auto with proof.
-- auto with proof.
+induction Hp.
+- forward; auto with proof.
+- forward; auto with proof.
 - apply AndR; auto with proof.
-- constructor 4. exch 0; do 2 backward. apply IHHp. ms.
+- forward; constructor 4. exch 0; do 2 backward. apply IHHp. ms.
 - apply OrR1. auto with proof.
 - apply OrR2. auto with proof.
-- constructor 7; backward; [apply IHHp1 | apply IHHp2]; ms.
+- forward; constructor 7; backward; [apply IHHp1 | apply IHHp2]; ms.
 - constructor 8. backward. apply IHHp. ms.
-- forward. exch 0. constructor 9. exch 0. do 2 backward. apply IHHp. ms.
+- do 2 forward. exch 0. constructor 9. exch 0. do 2 backward. apply IHHp. ms.
 - case (decide (((φ0 ∧ φ4) → φ5) = ((φ1 ∧ φ2) → φ3))); intro Heq0.
-  + inversion Heq0; subst. peapply Hp.
+  + dependent destruction Heq0; subst. peapply Hp.
   + forward. constructor 10. backward. apply IHHp. ms.
-- constructor 11; exch 0; do 2 backward; apply IHHp; ms.
-- constructor 12; backward; (apply IHHp1 || apply IHHp2); ms.
--  apply ImpBox; repeat box_tac.
+- forward; constructor 11; exch 0; do 2 backward; apply IHHp; ms.
+- forward; constructor 12; backward; (apply IHHp1 || apply IHHp2); ms.
+- forward; apply ImpBox; repeat box_tac.
   + exch 0; do 2 backward. apply IHHp1. ms.
   + backward. apply IHHp2. ms.
 - apply BoxR. repeat box_tac. backward. apply IHHp. ms.
@@ -449,23 +465,34 @@ Global Hint Resolve ImpLOr_rev : proof.
 Global Hint Resolve ImpLAnd_rev : proof.
 Global Hint Resolve ImpLBox_prev : proof.
 
-Lemma exfalso Γ φ: Γ ⊢ ⊥ -> Γ ⊢ φ.
+
+Lemma exfalso {K : Kind} Γ φ: Γ ⊢ ⊥ -> Γ ⊢ φ.
 Proof.
 intro Hp. dependent induction Hp; try tauto; auto with proof; tauto.
 Qed.
 
 Global Hint Immediate exfalso : proof.
 
-Lemma AndR_rev {Γ φ1 φ2} : Γ ⊢ φ1 ∧ φ2 -> (Γ ⊢ φ1) * (Γ ⊢ φ2).
-Proof. intro Hp. dependent induction Hp generalizing φ1 φ2 Hp; intuition; auto with proof. Qed.
+Lemma AndR_rev {K : Kind} {Γ φ1 φ2} : Γ ⊢ φ1 ∧ φ2 -> (Γ ⊢ φ1) * (Γ ⊢ φ2).
+Proof.
+  intro Hp. dependent induction Hp generalizing φ1 φ2 Hp;
+  try specialize (IHHp _ _ eq_refl);
+  try specialize (IHHp1 _ _ eq_refl);
+  try specialize (IHHp2 _ _ eq_refl);
+  intuition; 
+  auto with proof.
+Qed.
 
 
 (** A general inversion rule for disjunction is not admissible. However, inversion holds if one of the formulas is ⊥. *)
 
-Lemma OrR1Bot_rev Γ φ :  Γ ⊢ φ ∨ ⊥ -> Γ ⊢ φ.
-Proof. intro Hd. dependent induction Hd; auto with proof. Qed.
-Lemma OrR2Bot_rev Γ φ :  Γ ⊢ ⊥ ∨ φ -> Γ ⊢ φ.
-Proof. intro Hd. dependent induction Hd; auto with proof. Qed.
+Lemma OrR1Bot_rev {K : Kind} Γ φ :  Γ ⊢ φ ∨ ⊥ -> Γ ⊢ φ.
+Proof. intro Hd.
+ dependent induction Hd generalizing φ; auto using exfalso with proof. Qed.
+ 
+Lemma OrR2Bot_rev {K : Kind} Γ φ :  Γ ⊢ ⊥ ∨ φ -> Γ ⊢ φ.
+Proof. intro Hd. dependent induction Hd; auto using exfalso with proof. Qed.
+
 
 (** We prove Lemma 4.1 of (Dyckhoff & Negri 2000). This lemma shows that a
     weaker version of the ImpL rule of Gentzen's original calculus LJ is still
@@ -473,7 +500,7 @@ Proof. intro Hd. dependent induction Hd; auto with proof. Qed.
     proved above.
   *)
 
-Lemma weak_ImpL Γ φ ψ θ :Γ ⊢ φ -> Γ•ψ ⊢ θ -> Γ•(φ → ψ) ⊢ θ.
+Lemma weak_ImpL {K : Kind} Γ φ ψ θ :Γ ⊢ φ -> Γ•ψ ⊢ θ -> Γ•(φ → ψ) ⊢ θ.
 Proof with (auto with proof).
 intro Hp. revert ψ θ. induction Hp; intros ψ0 θ0 Hp'.
 - apply ImpLVar, Hp'.
@@ -505,7 +532,7 @@ Global Hint Resolve weak_ImpL : proof.
  G4ip. *)
 
 (** An auxiliary definition of **height** of a proof, measured along the leftmost branch. *)
-Fixpoint height {Γ φ} (Hp : Γ ⊢ φ) := match Hp with
+Fixpoint height {K : Kind} {Γ φ} (Hp : Γ ⊢ φ) := match Hp with
 | Atom _ _ => 1
 | ExFalso _ _ => 1
 | AndR Γ φ ψ H1 H2 => 1 + height H1 + height H2
@@ -522,12 +549,12 @@ Fixpoint height {Γ φ} (Hp : Γ ⊢ φ) := match Hp with
 | BoxR Γ φ H => 1 + height H
 end.
 
-Lemma height_0 {Γ φ} (Hp : Γ ⊢ φ) : height Hp <> 0.
+Lemma height_0 {K : Kind} {Γ φ} (Hp : Γ ⊢ φ) : height Hp <> 0.
 Proof. destruct Hp; simpl; lia. Qed.
 
 (** Lemma 4.2 in (Dyckhoff & Negri 2000), showing that a "duplication" in the context of the implication-case of the implication-left rule is admissible. *)
 
-Lemma ImpLImp_dup Γ φ1 φ2 φ3 θ:
+Lemma ImpLImp_dup {K : Kind} Γ φ1 φ2 φ3 θ:
   Γ•((φ1 → φ2) → φ3) ⊢ θ ->
     Γ•φ1 •(φ2 → φ3) •(φ2 → φ3) ⊢ θ.
 Proof.
@@ -560,7 +587,7 @@ destruct Hp; simpl in Hleh.
 - forward. apply ImpLAnd. backward. apply IHh with Hp. lia. ms.
 - forward. apply ImpLOr. exch 0. do 2 backward. apply IHh with Hp. lia. ms.
 - case (decide (((φ0 → φ4) → φ5) = ((φ1 → φ2) → φ3))); intro Heq.
-  + inversion Heq; subst.
+  + dependent destruction Heq; subst.
     apply weak_ImpL.
     * exch 0. apply ImpR_rev. peapply Hp1.
     * do 2 (exch 0; apply weakening). peapply Hp2.
@@ -592,7 +619,7 @@ remember (height Hp) as h.
 assert(Hleh : height Hp ≤ h) by lia. clear Heqh.
 revert Γ0 θ Hp Hleh Hin. induction h as [|h]; intros Γ θ Hp Hleh Hin;
 [pose (height_0 Hp); lia|].
-destruct Hp; simpl in Hleh.
+dependent destruction Hp; simpl in Hleh.
 - forward. auto with proof.
 - forward. auto with proof.
 - apply AndR.
@@ -613,7 +640,7 @@ destruct Hp; simpl in Hleh.
   + backward. apply IHh with Hp1. lia. ms.
   + backward. apply IHh with Hp2. lia. ms.
 - case (decide ((□ φ0 → φ3) = □ φ1 → φ2)); intro Heq.
-  + inversion Heq; subst.
+  + dependent destruction Heq; subst.
       exch 0. apply weakening. exch 0. apply weakening. peapply Hp2.
   + forward. apply ImpBox; repeat box_tac.
       * exch 0. do 2 backward.
@@ -630,20 +657,20 @@ destruct Hp; simpl in Hleh.
 Qed.
 
 (* technical lemma for contraction *)
-Local Lemma p_contr Γ φ θ:
+Local Lemma p_contr {K : Kind} Γ φ θ:
   (Γ•φ•φ) ∖ {[φ]} ⊢ θ ->
   ((Γ•φ) ⊢ θ).
 Proof. intros * Hd; peapply Hd. Qed.
 
-Lemma is_box_weight_open_box φ : is_box φ = true -> weight (⊙ φ) = weight φ -1.
-Proof. destruct φ; simpl; lia. Qed. 
+Lemma is_box_weight_open_box {K : Kind} φ : is_box φ = true -> weight (⊙ φ) = weight φ -1.
+Proof. dependent destruction φ; simpl; lia. Qed. 
 
-Lemma weight_open_box φ : weight (⊙ φ) ≤ weight φ.
-Proof. destruct φ; simpl; lia. Qed. 
+Lemma weight_open_box {K : Kind} φ : weight (⊙ φ) ≤ weight φ.
+Proof. dependent destruction φ; simpl; lia. Qed. 
 
 
 (** Admissibility of contraction in G4ip. *)
-Lemma contraction Γ ψ θ : Γ•ψ•ψ ⊢ θ -> Γ•ψ ⊢ θ.
+Lemma contraction {K : Kind} Γ ψ θ : Γ • ψ • ψ ⊢ θ -> Γ • ψ ⊢ θ.
 Proof.
 remember (Γ•ψ•ψ) as Γ0 eqn:Heq0.
 assert(HeqΓ : (Γ•ψ) ≡ Γ0 ∖ {[ψ]}) by ms.
@@ -778,7 +805,8 @@ Qed.
 
 Global Hint Resolve contraction : proof.
 
-Theorem generalised_contraction (Γ Γ' : env) φ: Γ' ⊎ Γ' ⊎ Γ ⊢ φ -> Γ' ⊎ Γ ⊢ φ.
+Theorem generalised_contraction {K : Kind} (Γ Γ' : env) φ:
+  Γ' ⊎ Γ' ⊎ Γ ⊢ φ -> Γ' ⊎ Γ ⊢ φ.
 Proof.
 revert Γ.
 induction Γ' as [| x Γ' IHΓ'] using gmultiset_rec; intros Γ Hp.
@@ -791,14 +819,14 @@ Qed.
 (** We show that the general implication left rule of LJ is admissible in G4ip.
   This is Proposition 5.2 in (Dyckhoff Negri 2000). *)
 
-Lemma ImpL Γ φ ψ θ: Γ•(φ → ψ) ⊢ φ -> Γ•ψ  ⊢ θ -> Γ•(φ → ψ) ⊢ θ.
+Lemma ImpL {K : Kind} Γ φ ψ θ: Γ•(φ → ψ) ⊢ φ -> Γ•ψ  ⊢ θ -> Γ•(φ → ψ) ⊢ θ.
 Proof. intros H1 H2. apply contraction, weak_ImpL; auto with proof. Qed.
 
 
 (* Lemma 5.3 (Dyckhoff Negri 2000) shows that an implication on the left may be
    weakened. *)
 
-Lemma imp_cut φ Γ ψ θ: Γ•(φ → ψ) ⊢ θ -> Γ•ψ ⊢ θ.
+Lemma imp_cut {K : Kind} φ Γ ψ θ: Γ•(φ → ψ) ⊢ θ -> Γ•ψ ⊢ θ.
 Proof.
 intro Hp.
 remember (Γ•(φ → ψ)) as Γ0 eqn:HH.
@@ -814,37 +842,37 @@ induction Hp.
 - forward. auto with proof.
 - forward. auto with proof.
 -apply AndR; intuition.
-- forward; apply AndL. exch 0. do 2 backward. apply IHHp. ms.
+- forward; apply AndL. exch 0. do 2 backward. apply IHHp; trivial. ms.
 - apply OrR1; intuition.
 - apply OrR2; intuition.
 - forward. apply OrL; backward; [apply IHHp1 | apply IHHp2]; ms.
-- apply ImpR. backward. apply IHHp. ms.
+- apply ImpR. backward. apply IHHp; trivial. ms.
 - case (decide ((p → φ0) = (φ → ψ))); intro Heq0.
-  + inversion Heq0; subst. peapply Hp.
+  + dependent destruction Heq0; subst. peapply Hp.
   + do 2 forward. exch 0. apply ImpLVar. exch 0. do 2 backward. apply IHHp; ms.
 - case (decide ((φ1 ∧ φ2 → φ3) = (φ → ψ))); intro Heq0.
-  + inversion Heq0; subst.
+  + dependent destruction Heq0; subst.
     assert(Heq1 : ((Γ•(φ1 ∧ φ2 → ψ)) ∖ {[φ1 ∧ φ2 → ψ]}) ≡ Γ) by ms;
     rw Heq1 1; clear Heq1. simpl in Hle.
     peapply (IHw (Γ•(φ2 → ψ)) φ2 ψ ψ0); [lia|ms|].
     peapply (IHw (Γ•(φ1 → φ2 → ψ)) φ1 (φ2 → ψ) ψ0); [lia|ms|trivial].
-  + forward. apply ImpLAnd. backward. apply IHHp. ms.
+  + forward. apply ImpLAnd. backward. apply IHHp; trivial. ms.
 - case (decide ((φ1 ∨ φ2 → φ3) = (φ → ψ))); intro Heq0.
-  + inversion Heq0. subst. clear Heq0.
+  + dependent destruction Heq0.
     apply contraction. simpl in Hle.
     peapply (IHw (Γ•ψ•(φ1 → ψ)) φ1 ψ); [lia|ms|].
     exch 0.
     peapply (IHw (Γ•(φ1 → ψ)•(φ2 → ψ)) φ2 ψ); trivial; [lia|ms].
   + forward. apply ImpLOr; exch 0; do 2 backward; apply IHHp; ms.
 - case (decide (((φ1 → φ2) → φ3) = (φ → ψ))); intro Heq0.
-  + inversion Heq0. subst. clear Heq0. peapply Hp2.
+  + dependent destruction Heq0. peapply Hp2.
   + forward. apply ImpLImp; backward; (apply IHHp1 || apply IHHp2); ms.
 - case (decide((□φ1 → φ2) = (φ → ψ))).
-  + intro Heq. inversion Heq. subst. clear Heq. peapply Hp2.
+  + intro Heq. dependent destruction Heq. peapply Hp2.
   + intro Hneq. forward. apply ImpBox; repeat box_tac.
-      * exch 0. do 2 backward. apply open_box_L. apply IHHp1. ms.
-      * backward. apply IHHp2. ms.
-- apply BoxR.  repeat box_tac. backward. apply open_box_L, IHHp.
+      * exch 0. do 2 backward. apply open_box_L. apply IHHp1; trivial. ms.
+      * backward. apply IHHp2; trivial. ms.
+- apply BoxR.  repeat box_tac. backward. apply open_box_L, IHHp; trivial.
   apply env_in_add. right. auto with proof.
 Qed.
 
@@ -857,7 +885,7 @@ induction Δ as [|ψ Δ IH] using gmultiset_rec.
 - right. ms.
 - case_eq(is_box ψ); intro Hbox.
   + left. exists (⊙ψ).
-      destruct ψ; try discriminate Hbox. ms.
+    dependent destruction ψ; try discriminate Hbox. ms.
   + destruct IH as [[φ Hφ]| Heq].
      * left. exists φ. ms.
      * right. symmetry. etransitivity.
@@ -866,13 +894,13 @@ induction Δ as [|ψ Δ IH] using gmultiset_rec.
         -- rewrite map_app, list_to_set_disj_app. rewrite <- Heq. apply env_equiv_eq.
             f_equal.
             unfold elements. apply is_not_box_open_box in Hbox.  rewrite <- Hbox at 2.
-            transitivity (list_to_set_disj (map open_box (id [ψ])) : env).
+            transitivity (list_to_set_disj (map open_box (id [ψ])) : @env Modal).
             ++ apply list_to_set_disj_perm, Permutation_map.
                     apply Permutation_refl', gmultiset_elements_singleton.
             ++ simpl. ms.
 Qed.
 
-Lemma OrR_idemp Γ ψ : Γ ⊢ ψ ∨ ψ -> Γ ⊢ ψ.
+Lemma OrR_idemp {K : Kind} Γ ψ : Γ ⊢ ψ ∨ ψ -> Γ ⊢ ψ.
 Proof. intro Hp. dependent induction Hp; auto with proof. Qed.
 
 
@@ -888,14 +916,14 @@ Qed.
   - [box_bot_not_tautology]: A boxed ⊥ cannot be a tautology.
 *)
 
-Lemma bot_not_tautology : (∅ ⊢ ⊥) -> False.
+Lemma bot_not_tautology {K : Kind} : (∅ ⊢ ⊥) -> False.
 Proof.
 intro Hf. dependent destruction Hf; simpl in *;
 match goal with x : _ ⊎ {[+?φ+]} = _ |- _ =>
 exfalso; eapply (gmultiset_elem_of_empty φ); setoid_rewrite <- x; ms end. 
 Qed.
 
-Lemma var_not_tautology v: (∅ ⊢ Var v) -> False.
+Lemma var_not_tautology {K : Kind} v: (∅ ⊢ Var v) -> False.
 Proof.
 intro Hp.
 remember ∅ as Γ.
@@ -945,7 +973,7 @@ try match goal with | Heq : (_ • ?f%stdpp) = _ |- _ => symmetry in Heq;
 Qed.
 
 (* A tautology is either equal to ⊤ or has a weight of at least 3. *)
-Lemma weight_tautology φ: (∅ ⊢ φ) -> {φ = ⊤} + {3 ≤ weight φ}.
+Lemma weight_tautology {K : Kind} φ: (∅ ⊢ φ) -> {φ = ⊤} + {3 ≤ weight φ}.
 Proof.
 intro Hp.
 destruct φ.
@@ -954,7 +982,7 @@ destruct φ.
 - right. simpl. pose(weight_pos φ1). pose(weight_pos φ2). lia.
 - right. simpl. pose(weight_pos φ1). pose(weight_pos φ2). lia.
 - right. simpl. pose(weight_pos φ1). pose(weight_pos φ2). lia.
-- destruct φ.
+- dependent destruction φ.
   + contradict Hp. apply  box_var_not_tautology.
   + contradict Hp. apply box_bot_not_tautology.
   + right. simpl. pose(weight_pos φ1). pose(weight_pos φ2). lia.

--- a/theories/iSL/SequentProps.v
+++ b/theories/iSL/SequentProps.v
@@ -1,7 +1,7 @@
 Require Import ISL.Sequents.
 
 (* Required for dependent induction. *)
-Require Import Coq.Program.Equality. 
+Require Import Coq.Program.Equality.
 
 (** * Admissible rules in G4ip sequent calculus
 
@@ -147,7 +147,7 @@ dependent induction Hp generalizing Γ' Hp; intros φ0 Hin.
       * intro. do 2 forward. exch 0. apply ImpLVar. exch 0. do 2 backward.
          apply IHHp; trivial. ms.
 - case (decide (φ0 =  (φ1 ∧ φ2 → φ3))).
-  + intro; subst; simpl. apply ImpLAnd. peapply Hp. 
+  + intro; subst; simpl. apply ImpLAnd. peapply Hp.
   + intro. forward. apply ImpLAnd. backward. apply IHHp; trivial. ms.
 - case (decide (φ0 =  (φ1 ∨ φ2 → φ3))).
   + intro; subst; simpl. apply ImpLOr. peapply Hp.
@@ -235,7 +235,7 @@ induction Hp; intros φ0 ψ0 Hin.
   + apply IHHp2. ms.
 - forward. constructor 13; repeat box_tac.
   + exch 0. box_tac.
-      apply In_open_boxes in Hin0. backward. backward. apply open_box_L. exch 0. apply open_box_L. exch 0. 
+      apply In_open_boxes in Hin0. backward. backward. apply open_box_L. exch 0. apply open_box_L. exch 0.
       apply IHHp1. ms.
   + backward. apply IHHp2. ms.
 - constructor 14. repeat box_tac.
@@ -390,7 +390,7 @@ dependent induction Hp.
   apply IHHp; trivial. ms.
 - forward; apply ImpLAnd. backward. apply IHHp; trivial. ms.
 - forward; apply ImpLOr. exch 0. do 2 backward. apply IHHp; trivial. ms.
-- forward; apply ImpLImp; backward. 
+- forward; apply ImpLImp; backward.
   + apply IHHp1; trivial. ms.
   + apply IHHp2; trivial. ms.
 - case (decide((□φ0 → φ3) = (□φ1 → φ2))).
@@ -479,7 +479,7 @@ Proof.
   try specialize (IHHp _ _ eq_refl);
   try specialize (IHHp1 _ _ eq_refl);
   try specialize (IHHp2 _ _ eq_refl);
-  intuition; 
+  intuition;
   auto with proof.
 Qed.
 
@@ -489,7 +489,7 @@ Qed.
 Lemma OrR1Bot_rev {K : Kind} Γ φ :  Γ ⊢ φ ∨ ⊥ -> Γ ⊢ φ.
 Proof. intro Hd.
  dependent induction Hd generalizing φ; auto using exfalso with proof. Qed.
- 
+
 Lemma OrR2Bot_rev {K : Kind} Γ φ :  Γ ⊢ ⊥ ∨ φ -> Γ ⊢ φ.
 Proof. intro Hd. dependent induction Hd; auto using exfalso with proof. Qed.
 
@@ -526,7 +526,7 @@ Qed.
 
 Global Hint Resolve weak_ImpL : proof.
 
-(** ** Contraction 
+(** ** Contraction
 
  The aim of this section is to prove that the contraction rule is admissible in
  G4ip. *)
@@ -663,10 +663,10 @@ Local Lemma p_contr {K : Kind} Γ φ θ:
 Proof. intros * Hd; peapply Hd. Qed.
 
 Lemma is_box_weight_open_box {K : Kind} φ : is_box φ = true -> weight (⊙ φ) = weight φ -1.
-Proof. dependent destruction φ; simpl; lia. Qed. 
+Proof. dependent destruction φ; simpl; lia. Qed.
 
 Lemma weight_open_box {K : Kind} φ : weight (⊙ φ) ≤ weight φ.
-Proof. dependent destruction φ; simpl; lia. Qed. 
+Proof. dependent destruction φ; simpl; lia. Qed.
 
 
 (** Admissibility of contraction in G4ip. *)
@@ -796,7 +796,7 @@ destruct Hp; simpl in Hleh, Hle.
       * backward. apply (IHh ψ Hle) with Hp2. lia. ms. ms.
 -  assert(Hinψ : ψ ∈ (Γ ∖ {[ψ]})) by ms. apply In_open_boxes in Hinψ.
    rewrite open_boxes_remove in Hinψ by trivial.
-  apply BoxR. box_tac. backward. apply IHh with Hp. 
+  apply BoxR. box_tac. backward. apply IHh with Hp.
     etransitivity. apply weight_open_box. trivial.
     lia.
     ms.
@@ -920,7 +920,7 @@ Lemma bot_not_tautology {K : Kind} : (∅ ⊢ ⊥) -> False.
 Proof.
 intro Hf. dependent destruction Hf; simpl in *;
 match goal with x : _ ⊎ {[+?φ+]} = _ |- _ =>
-exfalso; eapply (gmultiset_elem_of_empty φ); setoid_rewrite <- x; ms end. 
+exfalso; eapply (gmultiset_elem_of_empty φ); setoid_rewrite <- x; ms end.
 Qed.
 
 Lemma var_not_tautology {K : Kind} v: (∅ ⊢ Var v) -> False.

--- a/theories/iSL/Sequents.v
+++ b/theories/iSL/Sequents.v
@@ -103,13 +103,13 @@ Ltac exhibit Hin n := match n with
 | 3 => rewrite (proper_Provable _ _ (equiv_disj_union_compat_r(equiv_disj_union_compat_r (equiv_disj_union_compat_r (difference_singleton _ _ Hin)))) _ _ eq_refl)
 end.
 
-(** The tactic "forward" tries to change a goal of the form : 
+(** The tactic "forward" tries to change a goal of the form :
 
-((Γ•φ ∖ {[ψ]}•…) ⊢ … 
+((Γ•φ ∖ {[ψ]}•…) ⊢ …
 
-into 
+into
 
-((Γ ∖ {[ψ]}•…•φ) ⊢ … , 
+((Γ ∖ {[ψ]}•…•φ) ⊢ … ,
 
 by first proving that ψ ∈ Γ. *)
 
@@ -140,11 +140,11 @@ Ltac forward := match goal with
   exch 3; exch 2; exch 1; exch 0
 end.
 
-(** The tactic "backward" changes a goal of the form : 
+(** The tactic "backward" changes a goal of the form :
 
-((Γ ∖ {[ψ]}•…•φ) ⊢ …  
+((Γ ∖ {[ψ]}•…•φ) ⊢ …
 
-into 
+into
 
 ((Γ•φ ∖ {[ψ]}•…) ⊢ …,
 

--- a/theories/iSL/Simp_env.v
+++ b/theories/iSL/Simp_env.v
@@ -505,7 +505,6 @@ apply elem_of_list_to_set_disj in Hin.
   + split; intros φ0 Hp; peapply' Hp; equiv_tac.
 Qed.
 
-(* TODO: move *)
 Hint Resolve elem_of_list_to_set_disj : proof.
 
 Lemma equiv_env_simp_env {K : Kind} Δ: equiv_env (simp_env Δ) Δ.
@@ -653,13 +652,5 @@ repeat simp_env_tac; try (try (apply Provable_dec_of_Prop in Hc); contradict Hc;
 - eapply Nat.le_ngt. eapply Hf1. eauto. subst; trivial.
 - eapply Hf4. eauto. now apply Provable_dec_of_Prop.
 Qed.
-(* TODO clean ?
-  Definition equiv_env_simp_env := equiv_env_simp_env.
-  Definition equiv_form_simp_form:= equiv_form_simp_form.
-  Definition equiv_env_vars := equiv_env_vars.
-  Definition occurs_in_simp_form := occurs_in_simp_form.
-  Definition simp_env_idempotent := simp_env_idempotent.
-  Definition simp_env_nil := simp_env_nil.
-  *)
-End SoundS.
 
+End SoundS.

--- a/theories/iSL/Simp_env.v
+++ b/theories/iSL/Simp_env.v
@@ -1,4 +1,4 @@
-(** * Simplifications for formulas and contexts 
+(** * Simplifications for formulas and contexts
 
 This file defines the main simplifications for formulas and contexts,
 maintaining intuitionistic equivalence.
@@ -46,7 +46,7 @@ Proof.
     if (exists_dec (fIp p) Γ) then true else false | _ => false end)).
   destruct (exists_dec fp Γ) as [(θ & Hin & Hθ) | Hf].
   - left. subst fp. destruct θ. 2-6: auto with *.
-    case exists_dec as [(ψ &Hinψ & Hψ)|] in Hθ; [|auto with *]. 
+    case exists_dec as [(ψ &Hinψ & Hψ)|] in Hθ; [|auto with *].
     unfold fIp in Hψ. destruct ψ.  1-4, 6: auto with *.
     destruct ψ1. 2-6: auto with *. case decide in Hψ; [|auto with *].
     subst. apply elem_of_list_In in Hinψ, Hin.
@@ -101,7 +101,7 @@ Defined.
   This section defines a set of functions and notations for handling ternary
   conditional logic. The functions [sumor_bind0], [sumor_bind1], [sumor_bind2], and
   [sumor_bind3] provide a way to handle different levels of nested dependent sums and
-  propositions. Each function takes a sum type and applies a function to the left component 
+  propositions. Each function takes a sum type and applies a function to the left component
   if it exists, or returns a default value otherwise. The notations
   `cond '?' A '⋮₀' B`, `cond '?' A '⋮₁' B`, `cond '?' A '⋮₂' B`, and `cond '?' A '⋮₃' B`
   are provided to simplify the usage of these functions.
@@ -132,7 +132,7 @@ match qH with
 end.
 
 Definition sumor_bind3 {A A' A'' A'''} {B : Prop} {C}:
-  {q : A & {r : A' & { s : A'' | A''' q r s}}} + B -> 
+  {q : A & {r : A' & { s : A'' | A''' q r s}}} + B ->
   (forall x y z (_ : A''' x y z), C) -> C -> C :=
 λ qH f c,
 match qH with
@@ -166,15 +166,15 @@ Equations contextual_simp_form {K : Kind} : list form -> form -> form :=
 (** ** Weight lemmas
   This section contains several lemmas related to the properties of logical formulas
   and their weights in the context of the Lindenbaum-Tarski preorder. The lemmas
-  are used to reason about the relationship between the weights of formulas and 
+  are used to reason about the relationship between the weights of formulas and
   their simplified forms.
 *)
 
 Lemma contextual_simp_form_weight {K : Kind} Δ (φ : @form K):
   contextual_simp_form Δ φ = ⊤ /\
-       (φ = Bot 
+       (φ = Bot
     \/ (exists Heq : K = Modal, eq_rect K (fun K => @form K) φ Modal Heq = □ ⊥)
-    \/ exists (v : variable), 
+    \/ exists (v : variable),
         (φ = v \/
          exists Heq : K = Modal, eq_rect K (fun K => @form K) φ Modal Heq = □ v)
     ) \/
@@ -230,9 +230,9 @@ Qed.
 (** ** Simplifying environments
 
 This section contains the function [simp_env], which simplifies an environment (context) Δ.
-If none of the left rules are applicable anymore to Δ, then the function calls 
+If none of the left rules are applicable anymore to Δ, then the function calls
 [applicable_contextual_simp_form] to find a simplification for one of the formulas in Δ, given
-the fact that it appears in context Δ. 
+the fact that it appears in context Δ.
 We also define [simp_form], which tries to simplify a formula in the empty context.
 *)
 
@@ -250,7 +250,7 @@ case (decide (weight φ' < weight φ)).
 }
 destruct (exists_dec (λ φ, if Hs φ then true else false) Δ) as [[φ [Hin HH]]| Hf].
 - destruct (Hs φ) as [[φ' [Heq Hw]]| Hf].
-  + left. exists φ. exists φ'. repeat split; trivial. now apply elem_of_list_In. 
+  + left. exists φ. exists φ'. repeat split; trivial. now apply elem_of_list_In.
   + contradict HH.
 - right. intros φ Hin. apply elem_of_list_In in Hin. apply Hf in Hin.
   destruct (Hs φ) as [|Hf']. auto with *. apply Hf'.
@@ -519,7 +519,7 @@ case (Δ ⊢? ⊥).
 }
 intro Hbot.
 repeat simp_env_tac; (try (eapply equiv_env_trans; [apply Hind; intuition; order_tac|])).
-- apply elem_of_list_to_set_disj in Hc. 
+- apply elem_of_list_to_set_disj in Hc.
   split; intros φ Hp.
   + exhibit Hc 0. apply AndL. peapply' Hp.
   + do 2 l_tac'. apply AndL_rev. peapply' Hp.
@@ -530,11 +530,11 @@ repeat simp_env_tac; (try (eapply equiv_env_trans; [apply Hind; intuition; order
   + exhibit Hc2 0. exhibit Hc3 1. peapply ImpLVar. peapply' Hp.
   + l_tac'. peapply' (ImpLVar_rev (list_to_set_disj (rm φ1 (rm (φ1 → φ2) Δ))) φ1 φ2).
       peapply' Hp.
-- apply elem_of_list_to_set_disj in Hc0. 
+- apply elem_of_list_to_set_disj in Hc0.
   split; intros φ Hp.
   + exhibit Hc0 0. apply ImpLAnd. peapply' Hp.
   + l_tac'. apply ImpLAnd_rev. peapply' Hp.
--  apply elem_of_list_to_set_disj in Hc0. 
+-  apply elem_of_list_to_set_disj in Hc0.
   split; intros φ Hp.
   + exhibit Hc0 0. apply ImpLOr. peapply' Hp.
   + do 2 l_tac'. apply ImpLOr_rev. peapply' Hp.
@@ -545,11 +545,11 @@ repeat simp_env_tac; (try (eapply equiv_env_trans; [apply Hind; intuition; order
       apply additive_cut with φ0. trivial. peapply' Hp.
 - destruct Hc as [Hc [Heq Hw]]. apply elem_of_list_to_set_disj in Hc.
   subst. apply contextual_simp_form_spec. now apply elem_of_list_to_set_disj.
-- apply elem_of_list_to_set_disj in Hc. 
+- apply elem_of_list_to_set_disj in Hc.
   split; intros φ Hp.
   + exhibit Hc 0. apply ImpLAnd. peapply' Hp.
   + l_tac'. apply ImpLAnd_rev. peapply' Hp.
--  apply elem_of_list_to_set_disj in Hc. 
+-  apply elem_of_list_to_set_disj in Hc.
   split; intros φ Hp.
   + exhibit Hc 0. apply ImpLOr. peapply' Hp.
   + do 2 l_tac'. apply ImpLOr_rev. peapply' Hp.

--- a/theories/iSL/Simplifications.v
+++ b/theories/iSL/Simplifications.v
@@ -88,13 +88,13 @@ Module Type SimpT.
     (* Orders are preserved *)
   Parameter simp_env_order : forall {K : Kind}, forall Δ, env_order_refl (simp_env Δ) Δ.
   Parameter simp_form_weight: forall {K : Kind}, forall φ, weight(simp_form φ) <= weight φ.
-  Global Hint Resolve simp_env_order : order. 
+  Global Hint Resolve simp_env_order : order.
   Global Hint Resolve simp_env_order : order.
   Global Hint Resolve simp_form_weight : order.
 End SimpT.
 
 Module Type SimpProps (Import S : SimpT).
-  Parameter simp_env_pointed_env_order_L : forall {K : Kind}, 
+  Parameter simp_env_pointed_env_order_L : forall {K : Kind},
     forall pe Δ φ, (pe ≺· (simp_env Δ, φ)) -> pe ≺· (Δ, φ).
   Parameter simp_env_env_order_L: forall {K : Kind}, forall Δ Δ0, (Δ0 ≺ simp_env Δ) -> Δ0 ≺ Δ.
   Parameter simp_env_nil: forall {K : Kind}, simp_env [] = [].


### PR DESCRIPTION
Formulas and Sequents are now parameterized by a Kind (Modal for iSL or Normal for IPC) so that everything applies to both logics explicitly.